### PR TITLE
Adjust wording and add docs for ruby shared CI

### DIFF
--- a/.github/workflows/ruby-shared-ci.yml
+++ b/.github/workflows/ruby-shared-ci.yml
@@ -1,11 +1,11 @@
-name: Ruby CI
+name: Ruby Shared CI
 
 on:
   workflow_call:
 
 jobs:
   test:
-    name: Run Tests
+    name: Run Tests and Coverage
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -1,1 +1,35 @@
-# .github
+# GitHub Actions Workflows
+
+This repository stores both Starter Workflows and re-usable GitHub Actions Workflows for MIT Libraries.
+
+If your actions are only runable in a specific repository, this is not the place to store them.
+
+If your actions are currently copy/pasted across several similar repositories, consider moving them here and updating your other repos to run from the copy here.
+
+## Ruby CI
+
+You can (optionally) add this using a Starter Workflow by going to Actions in the repository you'd like it added to, and selecting the "MIT Libraries Ruby CI Workflow" which will allow you to open a PR to add this shared workflow.
+
+Requirements
+
+- Add `simplecov` and `simplecov-lcov` to the test section of Gemfile
+- `bundle install`
+- Add the following config to `test/test_helper.rb`
+
+Insert immediately after the ENV check on line 1.
+
+```ruby
+require 'simplecov'
+ require 'simplecov-lcov'
+ SimpleCov::Formatter::LcovFormatter.config.report_with_single_file = true
+ SimpleCov::Formatter::LcovFormatter.config.lcov_file_name = 'coverage.lcov'
+ SimpleCov.formatters = [
+   SimpleCov::Formatter::HTMLFormatter,
+   SimpleCov.formatter = SimpleCov::Formatter::LcovFormatter
+ ]
+ SimpleCov.start('rails')
+```
+
+- That's it! Adding the shared workflow should now run the standard tests and code coverage checks.
+
+If you don't want to use the Starter Workflow to add this Action, it is still a good place to see how to call this Shared Workflow.

--- a/workflow-templates/mit-libraries-ruby-ci.properties.json
+++ b/workflow-templates/mit-libraries-ruby-ci.properties.json
@@ -1,6 +1,6 @@
 {
   "name": "MIT Libraries Ruby CI Workflow",
-  "description": "MIT Libraries ruby workflow for tests and code coverage. [INSERT NOTE ON SIMPLECOV CONFIG]",
+  "description": "MIT Libraries ruby workflow for tests and code coverage. See MITLibraries/.github repo for instructions on preparing the Ruby app for this workflow.",
   "iconName": "ruby-icon",
   "categories": [
     "Ruby"

--- a/workflow-templates/mit-libraries-ruby-ci.yml
+++ b/workflow-templates/mit-libraries-ruby-ci.yml
@@ -6,5 +6,5 @@ on:
     branches: [ $default-branch ]
 
 jobs:
-  mitlibraries-ruby-ci:
-    uses: mitlibraries/.github/.github/workflows/ruby-ci.yml@main
+  tests-and-coverage:
+    uses: mitlibraries/.github/.github/workflows/ruby-shared-ci.yml@main


### PR DESCRIPTION
Why are these changes being introduced:

* This moves documentation for the temporary shared workflows repo as
  that is no longer needed.