### PR TITLE
Add Shared Terraform Workflows

### DIFF
--- a/.github/workflows/tf-checkov-shared.yml
+++ b/.github/workflows/tf-checkov-shared.yml
@@ -1,0 +1,27 @@
+## This github action runs Checkov against any terraform in the base directory. 
+## Checkov looks for common security related mistakes in terraform
+## Checkov generates findings and shows them in the actions tab.
+## More info about the action can be found here: https://www.checkov.io/4.Integrations/GitHub%20Actions.html
+## More info about what it checks can be found here: https://www.checkov.io/5.Policy%20Index/terraform.html
+
+name: Checkov
+on:
+  workflow_call:
+
+jobs:
+  checkov:
+    name: run checkov
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+      - name: Test with Checkov
+        id: checkov
+        uses: bridgecrewio/checkov-action@master
+        with:
+          directory: .
+          framework: terraform 
+          quiet: true

--- a/.github/workflows/tf-docs-gen-shared.yml
+++ b/.github/workflows/tf-docs-gen-shared.yml
@@ -1,0 +1,25 @@
+# This action appends a terraform docs markdown to the readme
+
+name: Generate terraform docs
+
+on:
+  workflow_call:
+
+jobs:
+  docs:
+    name: terraform-docs
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.pull_request.head.ref }}
+
+    - name: Render terraform docs and push changes back to PR
+      uses: terraform-docs/gh-actions@main
+      with:
+        working-dir: .
+        output-file: README.md
+        output-method: inject
+        git-push: "true"
+        args: --html=false --anchor=false
+        

--- a/.github/workflows/tf-validate-shared.yml
+++ b/.github/workflows/tf-validate-shared.yml
@@ -1,0 +1,25 @@
+name: Validate Terraform
+
+on:
+  workflow_call:
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  validate-terraform:
+    name: version 1.1.4
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Terraform Setup
+        uses: hashicorp/setup-terraform@v1
+        with:
+          terraform_version: 1.1.4
+      
+      - name: Check format and validate
+        run:
+          terraform fmt -check -recursive; terraform init -backend=false; terraform validate

--- a/README.md
+++ b/README.md
@@ -33,3 +33,13 @@ require 'simplecov'
 - That's it! Adding the shared workflow should now run the standard tests and code coverage checks.
 
 If you don't want to use the Starter Workflow to add this Action, it is still a good place to see how to call this Shared Workflow.
+
+## Terraform
+
+Since we use a template repo for all our Terraform repos, we don't need starter templates. But, we can definitely use shared workflows! There are three workflows in [`.github/workflows`](./.github/workflows) that are used in all of our Terraform repos: 
+
+* `terraform validate`: we always validate the Terraform code
+* `checkov`: we always run a security check on the Terraform code
+* `terraform-docs`: we automatically update the `README.md` with the output from the `terraform-docs` command
+
+All these shared workflows have `tf-` as a prefix.


### PR DESCRIPTION
Why these changes are being introduced:
InfraEng has many (many!) Terraform repos, all with the same three workflows: validate Terraform, run checkov security check, update README with terraform-docs output. The "validate Terraform" is linked to a specific version of Terraform, and if that ever had to be updated it would be a total nightmare. Seems like a good use case for a set of shared workflows.

This needs to be coordinated with updates to the [mitlib-tf-template](https://github.com/MITLibraries/mitlib-tf-template/tree/shared-workflows) repository. There is currently a feature branch in that repo with changes to the workflows to switch from the three workflows to the single "caller" workflow. If you view the Actions tab in the repo, you can see the result of the run that used the shared workflows.

Once this branch is committed to `main`, that feature branch will need to be updated to reference the `main` branch for the shared workflows (and then committed to its own `main` branch).

How this addresses that need:
* Add three Terraform-related workflows to the shared workflows list
* Update the README to reflect the new workflows

Side effects of this change:
None.