### PR TITLE
Workflows for automating Fargate & Lambda deploys

### DIFF
--- a/.github/workflows/fargate-shared-deploy-dev.yml
+++ b/.github/workflows/fargate-shared-deploy-dev.yml
@@ -1,0 +1,46 @@
+# This workflow runs Fargate container deployments dev ONLY
+name: Dev Fargate Deploy
+
+on:
+  workflow_call:
+    inputs:
+      AWS_REGION:
+        required: true
+        type: string
+      GHA_ROLE:
+        required: true
+        type: string
+      ECR:
+        required: true
+        type: string
+
+# Set defaults
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  deploy:
+    name: Deploy build
+    runs-on: ubuntu-latest
+    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCT_DEV }}:role/${{ inputs.GHA_ROLE }}
+          aws-region: ${{ inputs.AWS_REGION }}
+
+      - name: Build container
+        run: docker build --platform linux/amd64 -t ${{ secrets.AWS_ACCT_DEV }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:latest -t ${{ secrets.AWS_ACCT_DEV }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:`git describe --always` .
+
+      - name: Push container
+        run: |
+          docker login -u AWS -p $(aws ecr get-login-password --region ${{ inputs.AWS_REGION }}) ${{ secrets.AWS_ACCT_DEV }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com
+          docker push ${{ secrets.AWS_ACCT_DEV }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:latest
+          docker push ${{ secrets.AWS_ACCT_DEV }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:`git describe --always`

--- a/.github/workflows/fargate-shared-deploy-stage.yml
+++ b/.github/workflows/fargate-shared-deploy-stage.yml
@@ -1,0 +1,46 @@
+# This workflow runs Fargate container deployments stage ONLY
+name: Stage Fargate Deploy
+
+on:
+  workflow_call:
+    inputs:
+      AWS_REGION:
+        required: true
+        type: string
+      GHA_ROLE:
+        required: true
+        type: string
+      ECR:
+        required: true
+        type: string
+
+# Set defaults
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  deploy:
+    name: Deploy build
+    runs-on: ubuntu-latest
+    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCT_STAGE }}:role/${{ inputs.GHA_ROLE }}
+          aws-region: ${{ inputs.AWS_REGION }}
+
+      - name: Build container
+        run: docker build --platform linux/amd64 -t ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:latest -t ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:`git describe --always` .
+
+      - name: Push container
+        run: |
+          docker login -u AWS -p $(aws ecr get-login-password --region us-east-1) ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com
+          docker push ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:latest
+          docker push ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:`git describe --always`

--- a/.github/workflows/fargate-shared-promote-prod.yml
+++ b/.github/workflows/fargate-shared-promote-prod.yml
@@ -1,0 +1,59 @@
+# This workflow runs Fargate container promote-to-prod automated deployments
+name: Prod Fargate Promote
+ 
+on:
+  workflow_call:
+    inputs:
+      AWS_REGION:
+        required: true
+        type: string
+      GHA_ROLE_STAGE:
+        required: true
+        type: string
+      GHA_ROLE_PROD:
+        required: true
+        type: string
+      ECR:
+        required: true
+        type: string
+
+# Set defaults
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  deploy:
+    name: Promote Build to Prod
+    # Download from Stage then upload to Prod
+    runs-on: ubuntu-latest
+    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v2
+      
+      - name: Configure AWS credentials for Stage
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCT_STAGE }}:role/${{ inputs.GHA_ROLE_STAGE }}
+          aws-region: ${{ inputs.AWS_REGION }}
+      - name: Download container from Stage
+        run: |
+          docker login -u AWS -p $(aws ecr get-login-password --region ${{ inputs.AWS_REGION }}) ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com
+          docker pull ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:latest
+          docker tag ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:latest ${{ secrets.AWS_ACCT_PROD }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:latest
+          docker tag ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:latest ${{ secrets.AWS_ACCT_PROD }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:`git describe --always`
+
+      - name: Configure AWS credentials for Prod
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCT_PROD }}:role/${{ inputs.GHA_ROLE_PROD }}
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Upload container to Prod
+        run: |
+          docker login -u AWS -p $(aws ecr get-login-password --region ${{ inputs.AWS_REGION }}) ${{ secrets.AWS_ACCT_PROD }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com
+          docker push ${{ secrets.AWS_ACCT_PROD }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:latest
+          docker push ${{ secrets.AWS_ACCT_PROD }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:`git describe --always`

--- a/.github/workflows/lambda-shared-deploy-dev.yml
+++ b/.github/workflows/lambda-shared-deploy-dev.yml
@@ -1,0 +1,52 @@
+# This workflow runs Lambda container deployments dev ONLY
+name: Dev Lambda Container Deploy
+
+on:
+  workflow_call:
+    inputs:
+      AWS_REGION:
+        required: true
+        type: string
+      GHA_ROLE:
+        required: true
+        type: string
+      ECR:
+        required: true
+        type: string
+      FUNCTION:
+        required: true
+        type: string
+
+# Set defaults
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  deploy:
+    name: Deploy build
+    runs-on: ubuntu-latest
+    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCT_DEV }}:role/${{ inputs.GHA_ROLE }}
+          aws-region: ${{ inputs.AWS_REGION }}
+
+      - name: Build container
+        run: docker build --platform linux/amd64 -t ${{ secrets.AWS_ACCT_DEV }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:latest -t ${{ secrets.AWS_ACCT_DEV }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:`git describe --always` .
+
+      - name: Push container
+        run: |
+          docker login -u AWS -p $(aws ecr get-login-password --region ${{ inputs.AWS_REGION }}) ${{ secrets.AWS_ACCT_DEV }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com
+          docker push ${{ secrets.AWS_ACCT_DEV }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:latest
+          docker push ${{ secrets.AWS_ACCT_DEV }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:`git describe --always`
+
+      - name: Update Lambda Function
+        run: aws lambda update-function-code --function-name ${{ inputs.FUNCTION }} --image-uri ${{ secrets.AWS_ACCT_DEV }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:latest --query "LastUpdateStatusReasonCode" --output text

--- a/.github/workflows/lambda-shared-deploy-stage.yml
+++ b/.github/workflows/lambda-shared-deploy-stage.yml
@@ -1,0 +1,52 @@
+# This workflow runs lambda container deployments stage ONLY
+name: Stage Lambda Container Deploy
+
+on:
+  workflow_call:
+    inputs:
+      AWS_REGION:
+        required: true
+        type: string
+      GHA_ROLE:
+        required: true
+        type: string
+      ECR:
+        required: true
+        type: string
+      FUNCTION:
+        required: true
+        type: string
+
+# Set defaults
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  deploy:
+    name: Deploy build
+    runs-on: ubuntu-latest
+    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCT_STAGE }}:role/${{ inputs.GHA_ROLE }}
+          aws-region: ${{ inputs.AWS_REGION }}
+
+      - name: Build container
+        run: docker build --platform linux/amd64 -t ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:latest -t ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:`git describe --always` .
+
+      - name: Push container
+        run: |
+          docker login -u AWS -p $(aws ecr get-login-password --region ${{ inputs.AWS_REGION }}) ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com
+          docker push ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:latest
+          docker push ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:`git describe --always`
+
+      - name: Update Lambda Function
+        run: aws lambda update-function-code --function-name ${{ inputs.FUNCTION }} --image-uri ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:latest --query "LastUpdateStatusReasonCode" --output text

--- a/.github/workflows/lambda-shared-promote-prod.yml
+++ b/.github/workflows/lambda-shared-promote-prod.yml
@@ -1,0 +1,64 @@
+# This workflow runs Lambda container promote-to-prod automated deployments
+name: Prod Lambda Container Promote
+ 
+on:
+  workflow_call:
+    inputs:
+      AWS_REGION:
+        required: true
+        type: string
+      GHA_ROLE_STAGE:
+        required: true
+        type: string
+      GHA_ROLE_PROD:
+        required: true
+        type: string
+      ECR:
+        required: true
+        type: string
+      FUNCTION:
+        required: true
+        type: string
+
+# Set defaults
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  deploy:
+    name: Promote Build to Prod
+    # Download from Stage then upload to Prod
+    runs-on: ubuntu-latest
+    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v2
+      
+      - name: Configure AWS credentials for Stage
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCT_STAGE }}:role/${{ inputs.GHA_ROLE_STAGE }}
+          aws-region: ${{ inputs.AWS_REGION }}
+      - name: Download container from Stage
+        run: |
+          docker login -u AWS -p $(aws ecr get-login-password --region ${{ inputs.AWS_REGION }}) ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com
+          docker pull ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:latest
+          docker tag ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:latest ${{ secrets.AWS_ACCT_PROD }}.dkr.ecr.${{ inputs.AWS_REGION }}/${{ inputs.ECR }}:latest
+          docker tag ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:latest ${{ secrets.AWS_ACCT_PROD }}.dkr.ecr.${{ inputs.AWS_REGION }}/${{ inputs.ECR }}:`git describe --always`
+
+      - name: Configure AWS credentials for Prod
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCT_PROD }}:role/${{ inputs.GHA_ROLE_PROD }}
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Upload container to Prod
+        run: |
+          docker login -u AWS -p $(aws ecr get-login-password --region ${{ inputs.AWS_REGION }}) ${{ secrets.AWS_ACCT_PROD }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com
+          docker push ${{ secrets.AWS_ACCT_PROD }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:latest
+          docker push ${{ secrets.AWS_ACCT_PROD }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:`git describe --always`
+      - name: Update Lambda Function in Prod
+        run: aws lambda update-function-code --function-name ${{ inputs.FUNCTION }} --image-uri ${{ secrets.AWS_ACCT_PROD }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:latest --query "LastUpdateStatusReasonCode" --output text

--- a/README.md
+++ b/README.md
@@ -7,13 +7,17 @@ If your actions are only runable in a specific repository, this is not the place
 If your actions are currently copy/pasted across several similar repositories, consider moving them here and updating your other repos to run from the copy here.
 
 ## Python CI
+
 ### Requirements
+
 Ensure the repo using these re-usable workflow(s) has all of the following:
+
 - A .python-version file specifying the same Python version as the Pipfile
 - A Pipfile with `pytest` and `coverage` in the dev-packages section
 - If using the linting workflow, a Makefile with a `make lint` command. See the [oai-pmh-harvester repo Makefile](https://github.com/MITLibraries/oai-pmh-harvester/blob/213d610c2095145b071e7ba730a282c578111579/Makefile) for an example of standard linter usage.
 
 In the repo where you want to use these workflows, add a `ci.yml` file in`.github/workflows` containing the following:
+
 ```yaml
 name: CI
 on: push
@@ -58,8 +62,117 @@ If you don't want to use the Starter Workflow to add this Action, it is still a 
 
 Since we use a template repo for all our Terraform repos, we don't need starter templates. But, we can definitely use shared workflows! There are three workflows in [`.github/workflows`](./.github/workflows) that are used in all of our Terraform repos:
 
-* `terraform validate`: we always validate the Terraform code
-* `checkov`: we always run a security check on the Terraform code
-* `terraform-docs`: we automatically update the `README.md` with the output from the `terraform-docs` command
+- `terraform validate`: we always validate the Terraform code
+- `checkov`: we always run a security check on the Terraform code
+- `terraform-docs`: we automatically update the `README.md` with the output from the `terraform-docs` command
 
 All these shared workflows have `tf-` as a prefix.
+
+## Publish Lambda Container
+
+**WIP**: This is a work-in-progress, but it seems that the workflow automation for deploying updated containers in Lambda functions will be similar across repos. There are two workflows:
+
+- For build/push/update of container & Lambda in dev and stage: [lambda-shared-deploy.yml](.github/workflows/lambda-shared-deploy.yml)
+- For build/push/update of container & Lambda in prod: [lambda-shared-promote-prod.yml](.github/workflows/lambda-shared-promote-prod.yml)
+
+### lambda-shared-deploy.yml
+
+This requires
+
+1. certain commands in the Makefile of the Lambda/Container repo
+1. a caller workflow that passes certain values to the shared workflow to set the environment in the runner
+1. secrets set in the repo (or set as shared secrets for all of MITLibraries GitHub Org)
+
+The `Makefile` header must contain
+
+```makefile
+SHELL=/bin/bash
+DATETIME:=$(shell date -u +%Y%m%dT%H%M%SZ)
+FUNC=$(FUNC_NAME)
+ECR_REPO=$(REPO_NAME)
+ECR=$(shell aws sts get-caller-identity --query Account --output text).dkr.ecr.us-east-1.amazonaws.com
+ECR_PROD=$(AWS_ACCOUNT_ID_PROD).dkr.ecr.us-east-1.amazonaws.com
+```
+
+and it must contain the following commands
+
+```makefile
+gha-dist: ## Build docker container (only used by GitHub Actions)
+  docker build --platform linux/amd64 \
+    -t $(ECR)/$(ECR_REPO):latest \
+    -t $(ECR)/$(ECR_REPO):`git describe --always` . 
+
+gha-publish: ## Push the dev image to ECR in Stage-Workloads (only used by GitHub Actions)
+  docker login -u AWS -p $$(aws ecr get-login-password --region us-east-1) $(ECR)
+  docker push $(ECR)/$(ECR_REPO):latest
+  docker push $(ECR)/$(ECR_REPO):`git describe --always`
+
+gha-update-lambda: ## Updates the lambda with whatever is the most recent image in the ecr (only used by GitHub Actions)
+  aws lambda update-function-code --function-name $(FUNC) --image-uri $(ECR)/$(ECR_REPO):latest
+```
+
+A sample caller workflow should look like
+
+```yaml
+jobs:
+  deploy:
+    name: Deploy Container to Lambda in Dev1
+    uses: mitlibraries/.github/.github/workflows/lambda-shared-deploy.yml@main
+    with:
+      GHA_ROLE: "lambda-image-gha-dev"
+      REGION: "us-east-1"
+      FUNC_NAME: "dev-lambda-image"
+      REPO_NAME: "lambda-image"
+    secrets:
+      AWS_ACCT: ${{ secrets.AWS_DEV1_ACCT }}
+```
+
+### lambda-shared-promote-prod.yml
+
+Similar to the previous workflow, there are multiple requirements for the `Makefile` and the caller workflow.
+
+The `Makefile` needs the following commands (the header is the same as above). Note that the first command here is the same as the `gha-update-lambda` command as above.
+
+```makefile
+gha-update-lambda: ## Updates the lambda with whatever is the most recent image in the ecr (only used by GitHub Actions)
+  aws lambda update-function-code \
+    --function-name $(FUNC) \
+    --image-uri $(ECR)/$(ECR_REPO):latest
+
+gha-download-stage: ## Get the stage image from ECR in Stage (only used by GitHub Actions)
+  docker login -u AWS -p $$(aws ecr get-login-password --region us-east-1) $(ECR)
+  docker pull $(ECR)/$(ECR_REPO):latest
+  docker tag $(ECR)/$(ECR_REPO):latest $(ECR_PROD)/$(ECR_REPO):latest
+  docker tag $(ECR)/$(ECR_REPO):latest $(ECR_PROD)/$(ECR_REPO):`git describe --always`
+
+gha-deploy-prod: ## Copy the downloaded image from runner to Prod ECR (only used by GitHub Actions)
+  docker login -u AWS -p $$(aws ecr get-login-password --region us-east-1) $(ECR_PROD)
+  docker push $(ECR_PROD)/$(ECR_REPO):latest
+  docker push $(ECR_PROD)/$(ECR_REPO):`git describe --always`
+```
+
+A sample caller workflow would look like
+
+```yaml
+jobs:
+  deploy:
+    name: Promote
+    uses: mitlibraries/.github/.github/workflows/lambda-shared-promote-prod.yml@main
+    with:
+      GHA_ROLE_STAGE: "lambda-image-gha-stage"
+      GHA_ROLE_PROD: "lambda-image-gha-prod"
+      REGION: "us-east-1"
+      FUNC: "prod-lambda-image"
+      REPO: "lambda-image"
+    secrets:
+      AWS_ACCT_STAGE: ${{ secrets.AWS_STAGE_ACCT }}
+      AWS_ACCT_PROD: ${{ secrets.AWS_PROD_ACCT }}
+```
+
+### Additional Requirements/Dependencies
+
+It also depends on the appropriate infrastructure in place, particularly the OIDC configuration and IAM role for Github Actions to connect to AWS.
+
+## Publish Fargate Container
+
+**WIP**: This hasn't started yet.


### PR DESCRIPTION
## Why are these changes being introduced:

We are moving toward more automation for building & deploying container-based apps in AWS. The shared workflows here cover the build/deploy automation for Fargate containers and for Lambda-fied containers. These are built to match the workflow that the developers are used to:
1. PR to `main` triggers a build/deploy of the container (or container+Lambda) in our Dev1 AWS Account
2. Merge to `main` triggers a build/deploy of the container (or conatiner+Lambda) in our Stage-Workloads AWS Account
3. Tagged release on `main` triggers a copy/paste (e.g., download/upload) of the container (or container+Lambda) from Stage-Workloads to Prod-Workloads.

The triggering is handled in the application repo with a caller workflow that calls these shared workflows along with some passed variables.

## Related Jira task/ticket

https://mitlibraries.atlassian.net/browse/IN-519

## How does this address that need:

* Add three Fargate-related workflows for building a container and deploying the container to the ECR repository in AWS
* Add three Lambda-related workflows for building a container, deploying the container to the ECR repository in AWS, and then updating the Lambda function to use the new container from the ECR repo

These shared workflows have already been tested in the context of PPOD, Alma WebHook, and some of the Timdex-related containers. It's important to note that for the Fargate build/deploy process, these shared workflows do **not** force an update on the ECS task/cluster (for now, it assumes that the Fargate containers are not long-running containers that need a forced update).

