### PR TITLE
Fix prod-promote

### DIFF
--- a/.github/workflows/fargate-shared-promote-prod.yml
+++ b/.github/workflows/fargate-shared-promote-prod.yml
@@ -13,7 +13,10 @@ on:
       GHA_ROLE_PROD:
         required: true
         type: string
-      ECR:
+      ECR_STAGE:
+        required: true
+        type: string
+      ECR_PROD:
         required: true
         type: string
 
@@ -43,9 +46,9 @@ jobs:
       - name: Download container from Stage
         run: |
           docker login -u AWS -p $(aws ecr get-login-password --region ${{ inputs.AWS_REGION }}) ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com
-          docker pull ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:latest
-          docker tag ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:latest ${{ secrets.AWS_ACCT_PROD }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:latest
-          docker tag ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:latest ${{ secrets.AWS_ACCT_PROD }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:`git describe --always`
+          docker pull ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR_STAGE }}:latest
+          docker tag ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR_STAGE }}:latest ${{ secrets.AWS_ACCT_PROD }}.dkr.ecr.${{ inputs.AWS_REGION }}/${{ inputs.ECR_PROD }}:latest
+          docker tag ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR_STAGE }}:latest ${{ secrets.AWS_ACCT_PROD }}.dkr.ecr.${{ inputs.AWS_REGION }}/${{ inputs.ECR_PROD }}:`git describe --always`
 
       - name: Configure AWS credentials for Prod
         uses: aws-actions/configure-aws-credentials@v1
@@ -55,5 +58,5 @@ jobs:
       - name: Upload container to Prod
         run: |
           docker login -u AWS -p $(aws ecr get-login-password --region ${{ inputs.AWS_REGION }}) ${{ secrets.AWS_ACCT_PROD }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com
-          docker push ${{ secrets.AWS_ACCT_PROD }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:latest
-          docker push ${{ secrets.AWS_ACCT_PROD }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:`git describe --always`
+          docker push ${{ secrets.AWS_ACCT_PROD }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR_PROD }}:latest
+          docker push ${{ secrets.AWS_ACCT_PROD }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR_PROD }}:`git describe --always`

--- a/.github/workflows/fargate-shared-promote-prod.yml
+++ b/.github/workflows/fargate-shared-promote-prod.yml
@@ -47,8 +47,8 @@ jobs:
         run: |
           docker login -u AWS -p $(aws ecr get-login-password --region ${{ inputs.AWS_REGION }}) ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com
           docker pull ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR_STAGE }}:latest
-          docker tag ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR_STAGE }}:latest ${{ secrets.AWS_ACCT_PROD }}.dkr.ecr.${{ inputs.AWS_REGION }}/${{ inputs.ECR_PROD }}:latest
-          docker tag ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR_STAGE }}:latest ${{ secrets.AWS_ACCT_PROD }}.dkr.ecr.${{ inputs.AWS_REGION }}/${{ inputs.ECR_PROD }}:`git describe --always`
+          docker tag ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR_STAGE }}:latest ${{ secrets.AWS_ACCT_PROD }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR_PROD }}:latest
+          docker tag ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR_STAGE }}:latest ${{ secrets.AWS_ACCT_PROD }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR_PROD }}:`git describe --always`
 
       - name: Configure AWS credentials for Prod
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/lambda-shared-promote-prod.yml
+++ b/.github/workflows/lambda-shared-promote-prod.yml
@@ -50,8 +50,8 @@ jobs:
         run: |
           docker login -u AWS -p $(aws ecr get-login-password --region ${{ inputs.AWS_REGION }}) ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com
           docker pull ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR_STAGE }}:latest
-          docker tag ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR_STAGE }}:latest ${{ secrets.AWS_ACCT_PROD }}.dkr.ecr.${{ inputs.AWS_REGION }}/${{ inputs.ECR_PROD }}:latest
-          docker tag ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR_STAGE }}:latest ${{ secrets.AWS_ACCT_PROD }}.dkr.ecr.${{ inputs.AWS_REGION }}/${{ inputs.ECR_PROD }}:`git describe --always`
+          docker tag ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR_STAGE }}:latest ${{ secrets.AWS_ACCT_PROD }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR_PROD }}:latest
+          docker tag ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR_STAGE }}:latest ${{ secrets.AWS_ACCT_PROD }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR_PROD }}:`git describe --always`
 
       - name: Configure AWS credentials for Prod
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/lambda-shared-promote-prod.yml
+++ b/.github/workflows/lambda-shared-promote-prod.yml
@@ -13,7 +13,10 @@ on:
       GHA_ROLE_PROD:
         required: true
         type: string
-      ECR:
+      ECR_STAGE:
+        required: true
+        type: string
+      ECR_PROD:
         required: true
         type: string
       FUNCTION:
@@ -46,9 +49,9 @@ jobs:
       - name: Download container from Stage
         run: |
           docker login -u AWS -p $(aws ecr get-login-password --region ${{ inputs.AWS_REGION }}) ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com
-          docker pull ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:latest
-          docker tag ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:latest ${{ secrets.AWS_ACCT_PROD }}.dkr.ecr.${{ inputs.AWS_REGION }}/${{ inputs.ECR }}:latest
-          docker tag ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:latest ${{ secrets.AWS_ACCT_PROD }}.dkr.ecr.${{ inputs.AWS_REGION }}/${{ inputs.ECR }}:`git describe --always`
+          docker pull ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR_STAGE }}:latest
+          docker tag ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR_STAGE }}:latest ${{ secrets.AWS_ACCT_PROD }}.dkr.ecr.${{ inputs.AWS_REGION }}/${{ inputs.ECR_PROD }}:latest
+          docker tag ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR_STAGE }}:latest ${{ secrets.AWS_ACCT_PROD }}.dkr.ecr.${{ inputs.AWS_REGION }}/${{ inputs.ECR_PROD }}:`git describe --always`
 
       - name: Configure AWS credentials for Prod
         uses: aws-actions/configure-aws-credentials@v1
@@ -58,7 +61,7 @@ jobs:
       - name: Upload container to Prod
         run: |
           docker login -u AWS -p $(aws ecr get-login-password --region ${{ inputs.AWS_REGION }}) ${{ secrets.AWS_ACCT_PROD }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com
-          docker push ${{ secrets.AWS_ACCT_PROD }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:latest
-          docker push ${{ secrets.AWS_ACCT_PROD }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:`git describe --always`
+          docker push ${{ secrets.AWS_ACCT_PROD }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR_PROD }}:latest
+          docker push ${{ secrets.AWS_ACCT_PROD }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR_PROD }}:`git describe --always`
       - name: Update Lambda Function in Prod
-        run: aws lambda update-function-code --function-name ${{ inputs.FUNCTION }} --image-uri ${{ secrets.AWS_ACCT_PROD }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:latest --query "LastUpdateStatusReasonCode" --output text
+        run: aws lambda update-function-code --function-name ${{ inputs.FUNCTION }} --image-uri ${{ secrets.AWS_ACCT_PROD }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR_PROD }}:latest --query "LastUpdateStatusReasonCode" --output text


### PR DESCRIPTION
## Background

The shared workflows for promoting Fargate containers and Lambda functions to Production were flawed. The `docker` commands need to be able to distinguish between the stage and prod ECR repository names, and that wasn't possible in the first version. This updates those workflows to use two different ECR repo related variables (one for the ECR_STAGE name and one for the ECR_PROD name) and the `docker pull`, `docker tag`, and `docker push` commands are now updated to use those two different variables.

This PR will need to be merged to `main` before the related fix to the [mitlib-tf-workloads-ecr](https://github.com/MITLibraries/mitlib-tf-workloads-ecr) repo can be merged to `main`.

See https://github.com/MITLibraries/mitlib-tf-workloads-ecr/pull/9.

## How to test

It will be possible to test these changes **before** merging this PR.
1. In the [alma-webhook-lambdas](https://github.com/MITLibraries/alma-webhook-lambdas/) repo, create a feature branch and in that branch, 
    a. manually update the `prod-promote.yml`caller workflow to reference the shared workflow in this `fix-lambda-deploys` branch (`uses: mitlibraries/.github/.github/workflows/lambda-shared-promote-prod.yml@fix-lambda-deploys`)
    b. manually change the single `with.ECR` line to `with.ECR_STAGE` and `with.ECR_PROD` (and put in the correct repo names)
2. From the Actions tab in [alma-webhook-lambdas](https://github.com/MITLibraries/alma-webhook-lambdas/) repo, manually trigger the `prod-promote.yml` Action (from the feature branch, not from `main`)

That should call the new version of the shared workflow and run it the same way it would triggered with a tagged release.

## Next steps

Assuming the test is successful, we can merge this PR. Once that is done, we can deal with the matching PR on the [mitlib-tf-workloads-ecr](https://github.com/MITLibraries/mitlib-tf-workloads-ecr) repo and push those changes through to `main`. Then, we can return to the [alma-webhook-lambdas](https://github.com/MITLibraries/alma-webhook-lambdas/) repo and in the same testing branch used above, update the `prod-promote.yml` workflow with the new Terraform output.

