### PR TITLE
Update tf-validate-shared.yml

### DIFF
--- a/.github/workflows/tf-validate-shared.yml
+++ b/.github/workflows/tf-validate-shared.yml
@@ -9,16 +9,14 @@ defaults:
 
 jobs:
   validate-terraform:
-    name: version 1.1.4
+    name: Check with a terraform fmt
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2
 
       - name: Terraform Setup
-        uses: hashicorp/setup-terraform@v1
-        with:
-          terraform_version: 1.1.4
+        uses: hashicorp/setup-terraform@v2
       
       - name: Check format and validate
         run:


### PR DESCRIPTION
# Subject
Update TF validate shared workflow to use latest version of terraform

# Why these changes are being introduced:
Rather than pin the version of terraform we're validating, this always uses the latest (stable) version of terraform.

# How this addresses that need:
Removes the version pin for the setup step, and updates it to use the latest version of setup (@v2)

# Side effects of this change:
None, other than all validates will be with latest using this shared workflow

# Testing/validation
To test, I updated the validate workflow in our almahook repo and had it run from there.  Previous runs were failing because they were using the older tf version, and after the change, validates are successful - 
https://github.com/MITLibraries/mitlib-tf-workloads-almahook/blob/dev/.github/workflows/tf-shared-workflows.yml
https://github.com/MITLibraries/mitlib-tf-workloads-almahook/actions/runs/2550250853