### PR TITLE
Update Ruby CI to run on Ubuntu 22.04

### DIFF
--- a/.github/workflows/ruby-shared-ci.yml
+++ b/.github/workflows/ruby-shared-ci.yml
@@ -6,13 +6,9 @@ on:
 jobs:
   test:
     name: Run Tests and Coverage
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
-      - name: Setup System
-        run: |
-          sudo apt update
-          sudo apt-get install libsqlite3-dev
       - uses: ruby/setup-ruby@v1
       - uses: actions/cache@v1
         with:


### PR DESCRIPTION
#### Why these changes are being introduced:

We are upgrading our Rails apps to use the Heroku 22 stack, which
requires Ubuntu 22.04.

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/ENGX-183

#### How this addresses that need:

This explicitly declares ubuntu-22.04 as the os for test job,
rather than ubuntu-latest.

#### Side effects of this change:

The system setup block has been removed, as `libsqlite3-dev` is
included in the new Heroku stack.