### PR TITLE
Update Ruby shared CI to use correct cache keys

### DIFF
--- a/.github/workflows/ruby-shared-ci.yml
+++ b/.github/workflows/ruby-shared-ci.yml
@@ -13,9 +13,9 @@ jobs:
       - uses: actions/cache@v1
         with:
           path: vendor/bundle
-          key: bundle-use-ruby-ubuntu-latest-${{ hashFiles('.ruby-version') }}-${{ hashFiles('**/Gemfile.lock') }}
+          key: bundle-use-ruby-ubuntu-22.04-${{ hashFiles('.ruby-version') }}-${{ hashFiles('**/Gemfile.lock') }}
           restore-keys: |
-            bundle-use-ruby-ubuntu-latest-${{ hashFiles('.ruby-version') }}-
+            bundle-use-ruby-ubuntu-22.04-${{ hashFiles('.ruby-version') }}-
       - name: bundle install
         run: |
           bundle config path vendor/bundle


### PR DESCRIPTION
#### Why these changes are being introduced:

We updated the Ruby CI to use Ubuntu 22.04, but the cache keys still
point to Ubuntu 20.

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/ENGX-183

#### How this addresses that need:

This updates the Ruby CI to use the correct cache keys.

#### Side effects of this change:

None.