### PR TITLE
Docker fixes

### DIFF
--- a/.github/workflows/fargate-shared-deploy-dev.yml
+++ b/.github/workflows/fargate-shared-deploy-dev.yml
@@ -36,11 +36,33 @@ jobs:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCT_DEV }}:role/${{ inputs.GHA_ROLE }}
           aws-region: ${{ inputs.AWS_REGION }}
 
+      - name: Create tags
+        id: tags
+        run: |
+          if [ $GITHUB_EVENT_NAME = "workflow_dispatch" ]; then
+            TAG_SHA=$(echo $GITHUB_SHA | cut -c 1-8)
+          else
+            TAG_SHA=$(echo ${{ github.event.pull_request.head.sha }} | cut -c 1-8)
+          fi
+          if [ $GITHUB_EVENT_NAME = "workflow_dispatch" ]; then
+            TAG_PR=$GITHUB_EVENT_NAME
+          else
+            TAG_PR=$(echo "PR-"${{ github.event.pull_request.number }})
+          fi
+          echo "::set-output name=tag_sha::$TAG_SHA"
+          echo "::set-output name=tag_pr::$TAG_PR"
+
       - name: Build container
-        run: DOCKER_BUILDKIT=1 docker build --platform linux/amd64 -t ${{ secrets.AWS_ACCT_DEV }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:latest -t ${{ secrets.AWS_ACCT_DEV }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:`git describe --always` .
+        run: |
+          TAG_SHA="${{ steps.tags.outputs.tag_sha }}"
+          TAG_PR="${{ steps.tags.outputs.tag_pr }}"
+          DOCKER_BUILDKIT=1 docker build --platform linux/amd64 -t ${{ secrets.AWS_ACCT_DEV }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:latest -t ${{ secrets.AWS_ACCT_DEV }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:`echo $TAG_SHA` -t ${{ secrets.AWS_ACCT_DEV }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:`echo $TAG_PR` .
 
       - name: Push container
         run: |
+          TAG_SHA="${{ steps.tags.outputs.tag_sha }}"
+          TAG_PR="${{ steps.tags.outputs.tag_pr }}"
           docker login -u AWS -p $(aws ecr get-login-password --region ${{ inputs.AWS_REGION }}) ${{ secrets.AWS_ACCT_DEV }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com
           docker push ${{ secrets.AWS_ACCT_DEV }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:latest
-          docker push ${{ secrets.AWS_ACCT_DEV }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:`git describe --always`
+          docker push ${{ secrets.AWS_ACCT_DEV }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:`echo $TAG_SHA`
+          docker push ${{ secrets.AWS_ACCT_DEV }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:`echo $TAG_PR`

--- a/.github/workflows/fargate-shared-deploy-dev.yml
+++ b/.github/workflows/fargate-shared-deploy-dev.yml
@@ -37,7 +37,7 @@ jobs:
           aws-region: ${{ inputs.AWS_REGION }}
 
       - name: Build container
-        run: docker build --platform linux/amd64 -t ${{ secrets.AWS_ACCT_DEV }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:latest -t ${{ secrets.AWS_ACCT_DEV }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:`git describe --always` .
+        run: DOCKER_BUILDKIT=1 docker build --platform linux/amd64 -t ${{ secrets.AWS_ACCT_DEV }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:latest -t ${{ secrets.AWS_ACCT_DEV }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:`git describe --always` .
 
       - name: Push container
         run: |

--- a/.github/workflows/fargate-shared-deploy-stage.yml
+++ b/.github/workflows/fargate-shared-deploy-stage.yml
@@ -37,10 +37,10 @@ jobs:
           aws-region: ${{ inputs.AWS_REGION }}
 
       - name: Build container
-        run: DOCKER_BUILDKIT=1 docker build --platform linux/amd64 -t ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:latest -t ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:`git describe --always` .
+        run: DOCKER_BUILDKIT=1 docker build --platform linux/amd64 -t ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:latest -t ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:`echo $GITHUB_SHA | cut -c 1-8` .
 
       - name: Push container
         run: |
           docker login -u AWS -p $(aws ecr get-login-password --region us-east-1) ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com
           docker push ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:latest
-          docker push ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:`git describe --always`
+          docker push ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:`echo $GITHUB_SHA | cut -c 1-8`

--- a/.github/workflows/fargate-shared-deploy-stage.yml
+++ b/.github/workflows/fargate-shared-deploy-stage.yml
@@ -37,7 +37,7 @@ jobs:
           aws-region: ${{ inputs.AWS_REGION }}
 
       - name: Build container
-        run: docker build --platform linux/amd64 -t ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:latest -t ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:`git describe --always` .
+        run: DOCKER_BUILDKIT=1 docker build --platform linux/amd64 -t ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:latest -t ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:`git describe --always` .
 
       - name: Push container
         run: |

--- a/.github/workflows/fargate-shared-promote-prod.yml
+++ b/.github/workflows/fargate-shared-promote-prod.yml
@@ -43,12 +43,22 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCT_STAGE }}:role/${{ inputs.GHA_ROLE_STAGE }}
           aws-region: ${{ inputs.AWS_REGION }}
-      - name: Download container from Stage
+      
+      - name: Create tags
+        id: tags
         run: |
+          echo "::set-output name=tag_sha::$GITHUB_SHA"
+          echo "::set-output name=tag_release::${{ github.event.release.tag_name }}"
+
+      - name: Download from Stage and re-tag
+        run: |
+          TAG_SHA="${{ steps.tags.outputs.tag_sha }}"
+          TAG_RELEASE="${{ steps.tags.outputs.tag_release }}"
           docker login -u AWS -p $(aws ecr get-login-password --region ${{ inputs.AWS_REGION }}) ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com
           docker pull ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR_STAGE }}:latest
           docker tag ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR_STAGE }}:latest ${{ secrets.AWS_ACCT_PROD }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR_PROD }}:latest
-          docker tag ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR_STAGE }}:latest ${{ secrets.AWS_ACCT_PROD }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR_PROD }}:`git describe --always`
+          docker tag ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR_STAGE }}:latest ${{ secrets.AWS_ACCT_PROD }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR_PROD }}:`echo $TAG_SHA`
+          docker tag ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR_STAGE }}:latest ${{ secrets.AWS_ACCT_PROD }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR_PROD }}:`echo $TAG_RELEASE`
 
       - name: Configure AWS credentials for Prod
         uses: aws-actions/configure-aws-credentials@v1
@@ -57,6 +67,9 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
       - name: Upload container to Prod
         run: |
+          TAG_SHA="${{ steps.tags.outputs.tag_sha }}"
+          TAG_RELEASE="${{ steps.tags.outputs.tag_release }}"
           docker login -u AWS -p $(aws ecr get-login-password --region ${{ inputs.AWS_REGION }}) ${{ secrets.AWS_ACCT_PROD }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com
           docker push ${{ secrets.AWS_ACCT_PROD }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR_PROD }}:latest
-          docker push ${{ secrets.AWS_ACCT_PROD }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR_PROD }}:`git describe --always`
+          docker push ${{ secrets.AWS_ACCT_PROD }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR_PROD }}:`echo $TAG_SHA`
+          docker push ${{ secrets.AWS_ACCT_PROD }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR_PROD }}:`echo $TAG_RELEASE`

--- a/.github/workflows/lambda-shared-deploy-dev.yml
+++ b/.github/workflows/lambda-shared-deploy-dev.yml
@@ -39,14 +39,36 @@ jobs:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCT_DEV }}:role/${{ inputs.GHA_ROLE }}
           aws-region: ${{ inputs.AWS_REGION }}
 
+      - name: Create tags
+        id: tags
+        run: |
+          if [ $GITHUB_EVENT_NAME = "workflow_dispatch" ]; then
+            TAG_SHA=$(echo $GITHUB_SHA | cut -c 1-8)
+          else
+            TAG_SHA=$(echo ${{ github.event.pull_request.head.sha }} | cut -c 1-8)
+          fi
+          if [ $GITHUB_EVENT_NAME = "workflow_dispatch" ]; then
+            TAG_PR=$GITHUB_EVENT_NAME
+          else
+            TAG_PR=$(echo "PR-"${{ github.event.pull_request.number }})
+          fi
+          echo "::set-output name=tag_sha::$TAG_SHA"
+          echo "::set-output name=tag_pr::$TAG_PR"
+
       - name: Build container
-        run: DOCKER_BUILDKIT=1 docker build --platform linux/amd64 -t ${{ secrets.AWS_ACCT_DEV }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:latest -t ${{ secrets.AWS_ACCT_DEV }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:`git describe --always` .
+        run: |
+          TAG_SHA="${{ steps.tags.outputs.tag_sha }}"
+          TAG_PR="${{ steps.tags.outputs.tag_pr }}"
+          DOCKER_BUILDKIT=1 docker build --platform linux/amd64 -t ${{ secrets.AWS_ACCT_DEV }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:latest -t ${{ secrets.AWS_ACCT_DEV }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:`echo $TAG_SHA` -t ${{ secrets.AWS_ACCT_DEV }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:`echo $TAG_PR` .
 
       - name: Push container
         run: |
+          TAG_SHA="${{ steps.tags.outputs.tag_sha }}"
+          TAG_PR="${{ steps.tags.outputs.tag_pr }}"
           docker login -u AWS -p $(aws ecr get-login-password --region ${{ inputs.AWS_REGION }}) ${{ secrets.AWS_ACCT_DEV }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com
           docker push ${{ secrets.AWS_ACCT_DEV }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:latest
-          docker push ${{ secrets.AWS_ACCT_DEV }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:`git describe --always`
-
+          docker push ${{ secrets.AWS_ACCT_DEV }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:`echo $TAG_SHA`
+          docker push ${{ secrets.AWS_ACCT_DEV }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:`echo $TAG_PR`
+ 
       - name: Update Lambda Function
         run: aws lambda update-function-code --function-name ${{ inputs.FUNCTION }} --image-uri ${{ secrets.AWS_ACCT_DEV }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:latest --query "LastUpdateStatusReasonCode" --output text

--- a/.github/workflows/lambda-shared-deploy-dev.yml
+++ b/.github/workflows/lambda-shared-deploy-dev.yml
@@ -40,7 +40,7 @@ jobs:
           aws-region: ${{ inputs.AWS_REGION }}
 
       - name: Build container
-        run: docker build --platform linux/amd64 -t ${{ secrets.AWS_ACCT_DEV }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:latest -t ${{ secrets.AWS_ACCT_DEV }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:`git describe --always` .
+        run: DOCKER_BUILDKIT=1 docker build --platform linux/amd64 -t ${{ secrets.AWS_ACCT_DEV }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:latest -t ${{ secrets.AWS_ACCT_DEV }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:`git describe --always` .
 
       - name: Push container
         run: |

--- a/.github/workflows/lambda-shared-deploy-stage.yml
+++ b/.github/workflows/lambda-shared-deploy-stage.yml
@@ -40,7 +40,7 @@ jobs:
           aws-region: ${{ inputs.AWS_REGION }}
 
       - name: Build container
-        run: docker build --platform linux/amd64 -t ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:latest -t ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:`git describe --always` .
+        run: DOCKER_BUILDKIT=1 docker build --platform linux/amd64 -t ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:latest -t ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:`git describe --always` .
 
       - name: Push container
         run: |

--- a/.github/workflows/lambda-shared-deploy-stage.yml
+++ b/.github/workflows/lambda-shared-deploy-stage.yml
@@ -40,13 +40,13 @@ jobs:
           aws-region: ${{ inputs.AWS_REGION }}
 
       - name: Build container
-        run: DOCKER_BUILDKIT=1 docker build --platform linux/amd64 -t ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:latest -t ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:`git describe --always` .
+        run: DOCKER_BUILDKIT=1 docker build --platform linux/amd64 -t ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:latest -t ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:`echo $GITHUB_SHA | cut -c 1-8` .
 
       - name: Push container
         run: |
           docker login -u AWS -p $(aws ecr get-login-password --region ${{ inputs.AWS_REGION }}) ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com
           docker push ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:latest
-          docker push ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:`git describe --always`
+          docker push ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:`echo $GITHUB_SHA | cut -c 1-8`
 
       - name: Update Lambda Function
         run: aws lambda update-function-code --function-name ${{ inputs.FUNCTION }} --image-uri ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR }}:latest --query "LastUpdateStatusReasonCode" --output text

--- a/.github/workflows/lambda-shared-promote-prod.yml
+++ b/.github/workflows/lambda-shared-promote-prod.yml
@@ -46,22 +46,37 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCT_STAGE }}:role/${{ inputs.GHA_ROLE_STAGE }}
           aws-region: ${{ inputs.AWS_REGION }}
-      - name: Download container from Stage
+
+      - name: Create tags
+        id: tags
         run: |
+          echo "::set-output name=tag_sha::$GITHUB_SHA"
+          echo "::set-output name=tag_release::${{ github.event.release.tag_name }}"
+
+      - name: Download from Stage and re-tag
+        run: |
+          TAG_SHA="${{ steps.tags.outputs.tag_sha }}"
+          TAG_RELEASE="${{ steps.tags.outputs.tag_release }}"
           docker login -u AWS -p $(aws ecr get-login-password --region ${{ inputs.AWS_REGION }}) ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com
           docker pull ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR_STAGE }}:latest
           docker tag ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR_STAGE }}:latest ${{ secrets.AWS_ACCT_PROD }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR_PROD }}:latest
-          docker tag ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR_STAGE }}:latest ${{ secrets.AWS_ACCT_PROD }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR_PROD }}:`git describe --always`
+          docker tag ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR_STAGE }}:latest ${{ secrets.AWS_ACCT_PROD }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR_PROD }}:`echo $TAG_SHA`
+          docker tag ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR_STAGE }}:latest ${{ secrets.AWS_ACCT_PROD }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR_PROD }}:`echo $TAG_RELEASE`
 
       - name: Configure AWS credentials for Prod
         uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCT_PROD }}:role/${{ inputs.GHA_ROLE_PROD }}
           aws-region: ${{ env.AWS_REGION }}
+
       - name: Upload container to Prod
         run: |
+          TAG_SHA="${{ steps.tags.outputs.tag_sha }}"
+          TAG_RELEASE="${{ steps.tags.outputs.tag_release }}"
           docker login -u AWS -p $(aws ecr get-login-password --region ${{ inputs.AWS_REGION }}) ${{ secrets.AWS_ACCT_PROD }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com
           docker push ${{ secrets.AWS_ACCT_PROD }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR_PROD }}:latest
-          docker push ${{ secrets.AWS_ACCT_PROD }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR_PROD }}:`git describe --always`
+          docker push ${{ secrets.AWS_ACCT_PROD }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR_PROD }}:`echo $TAG_SHA`
+          docker push ${{ secrets.AWS_ACCT_PROD }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR_PROD }}:`echo $TAG_RELEASE`
+
       - name: Update Lambda Function in Prod
         run: aws lambda update-function-code --function-name ${{ inputs.FUNCTION }} --image-uri ${{ secrets.AWS_ACCT_PROD }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR_PROD }}:latest --query "LastUpdateStatusReasonCode" --output text

--- a/README.md
+++ b/README.md
@@ -68,111 +68,106 @@ Since we use a template repo for all our Terraform repos, we don't need starter 
 
 All these shared workflows have `tf-` as a prefix.
 
-## Publish Lambda Container
 
-**WIP**: This is a work-in-progress, but it seems that the workflow automation for deploying updated containers in Lambda functions will be similar across repos. There are two workflows:
+## Publish Fargate Container
 
-- For build/push/update of container & Lambda in dev and stage: [lambda-shared-deploy.yml](.github/workflows/lambda-shared-deploy.yml)
-- For build/push/update of container & Lambda in prod: [lambda-shared-promote-prod.yml](.github/workflows/lambda-shared-promote-prod.yml)
+There are three workflows associated with publishing Docker containers. **Note**: The automated workflows deploy the updated container to the ECR repository, but the workflows **do not** force a container-based service to restart!
 
-### lambda-shared-deploy.yml
+- For build/push/update of Docker container in dev: [fargate-shared-deploy-dev.yml](.github/workflows/fargate-shared-deploy-dev.yml)
+- For build/push/update of Docker container in stage: [fargate-shared-deploy-stage.yml](.github/workflows/fargate-shared-deploy-stage.yml)
+- For promoting container to prod: [fargate-shared-promote-prod.yml](.github/workflows/fargate-shared-promote-prod.yml)
 
-This requires
+### fargate-shared-deploy-dev.yml & fargate-shared-deploy-stage.yml
 
-1. certain commands in the Makefile of the Lambda/Container repo
-1. a caller workflow that passes certain values to the shared workflow to set the environment in the runner
-1. secrets set in the repo (or set as shared secrets for all of MITLibraries GitHub Org)
+These two workflows are almost exactly the same. They require 
 
-The `Makefile` header must contain
-
-```makefile
-SHELL=/bin/bash
-DATETIME:=$(shell date -u +%Y%m%dT%H%M%SZ)
-FUNC=$(FUNC_NAME)
-ECR_REPO=$(REPO_NAME)
-ECR=$(shell aws sts get-caller-identity --query Account --output text).dkr.ecr.us-east-1.amazonaws.com
-ECR_PROD=$(AWS_ACCOUNT_ID_PROD).dkr.ecr.us-east-1.amazonaws.com
-```
-
-and it must contain the following commands
-
-```makefile
-gha-dist: ## Build docker container (only used by GitHub Actions)
-  docker build --platform linux/amd64 \
-    -t $(ECR)/$(ECR_REPO):latest \
-    -t $(ECR)/$(ECR_REPO):`git describe --always` . 
-
-gha-publish: ## Push the dev image to ECR in Stage-Workloads (only used by GitHub Actions)
-  docker login -u AWS -p $$(aws ecr get-login-password --region us-east-1) $(ECR)
-  docker push $(ECR)/$(ECR_REPO):latest
-  docker push $(ECR)/$(ECR_REPO):`git describe --always`
-
-gha-update-lambda: ## Updates the lambda with whatever is the most recent image in the ecr (only used by GitHub Actions)
-  aws lambda update-function-code --function-name $(FUNC) --image-uri $(ECR)/$(ECR_REPO):latest
-```
+- shared secrets that exists in our MITLibraries GitHub Organization.
+- a caller workflow that passes certain values to the shared workflow
 
 A sample caller workflow should look like
 
 ```yaml
 jobs:
   deploy:
-    name: Deploy Container to Lambda in Dev1
-    uses: mitlibraries/.github/.github/workflows/lambda-shared-deploy.yml@main
+    name: <env> Deploy Fargate Container
+    uses: mitlibraries/.github/.github/workflows/fargate-shared-deploy-<env>.yml@main
+    secrets: inherit
     with:
-      GHA_ROLE: "lambda-image-gha-dev"
-      REGION: "us-east-1"
-      FUNC_NAME: "dev-lambda-image"
-      REPO_NAME: "lambda-image"
-    secrets:
-      AWS_ACCT: ${{ secrets.AWS_DEV1_ACCT }}
+      AWS_REGION: "<aws_region>"
+      GHA_ROLE: "<name_of_iam_role_with_ecr_publish_permissions>"
+      ECR: "<name_of_ecr_repository>"
 ```
 
-### lambda-shared-promote-prod.yml
+### fargate-shared-promote-prod.yml
 
-Similar to the previous workflow, there are multiple requirements for the `Makefile` and the caller workflow.
-
-The `Makefile` needs the following commands (the header is the same as above). Note that the first command here is the same as the `gha-update-lambda` command as above.
-
-```makefile
-gha-update-lambda: ## Updates the lambda with whatever is the most recent image in the ecr (only used by GitHub Actions)
-  aws lambda update-function-code \
-    --function-name $(FUNC) \
-    --image-uri $(ECR)/$(ECR_REPO):latest
-
-gha-download-stage: ## Get the stage image from ECR in Stage (only used by GitHub Actions)
-  docker login -u AWS -p $$(aws ecr get-login-password --region us-east-1) $(ECR)
-  docker pull $(ECR)/$(ECR_REPO):latest
-  docker tag $(ECR)/$(ECR_REPO):latest $(ECR_PROD)/$(ECR_REPO):latest
-  docker tag $(ECR)/$(ECR_REPO):latest $(ECR_PROD)/$(ECR_REPO):`git describe --always`
-
-gha-deploy-prod: ## Copy the downloaded image from runner to Prod ECR (only used by GitHub Actions)
-  docker login -u AWS -p $$(aws ecr get-login-password --region us-east-1) $(ECR_PROD)
-  docker push $(ECR_PROD)/$(ECR_REPO):latest
-  docker push $(ECR_PROD)/$(ECR_REPO):`git describe --always`
-```
+The automated deploys to dev & stage actually build the container through GitHub Actions. The promote to prod workflow just copies the container from stage to prod to ensure that there is no difference at all in what is deployed.
 
 A sample caller workflow would look like
 
 ```yaml
 jobs:
   deploy:
-    name: Promote
-    uses: mitlibraries/.github/.github/workflows/lambda-shared-promote-prod.yml@main
+    name: Prod Promote Fargate Container
+    uses: mitlibraries/.github/.github/workflows/fargate-shared-promote-prod.yml@main
+    secrets: inherit
     with:
-      GHA_ROLE_STAGE: "lambda-image-gha-stage"
-      GHA_ROLE_PROD: "lambda-image-gha-prod"
-      REGION: "us-east-1"
-      FUNC: "prod-lambda-image"
-      REPO: "lambda-image"
-    secrets:
-      AWS_ACCT_STAGE: ${{ secrets.AWS_STAGE_ACCT }}
-      AWS_ACCT_PROD: ${{ secrets.AWS_PROD_ACCT }}
+      AWS_REGION: "<aws_region>"
+      GHA_ROLE_STAGE: "<name_of_iam_role_with_ecr_publish_permissions_in_stage>"
+      GHA_ROLE_PROD: "<name_of_iam_role_with_ecr_publish_permissions_in_prod>"
+      ECR_STAGE: "<name_of_ecr_repository_in_stage>"
+      ECR_PROD: "<name_of_ecr_repository_in_prod>"
 ```
 
 ### Additional Requirements/Dependencies
 
 It also depends on the appropriate infrastructure in place, particularly the OIDC configuration and IAM role for Github Actions to connect to AWS.
 
-## Publish Fargate Container
+**Note**: The caller workflows are generated by the Terraform code that creates the ECR and associated IAM Roles and permissions. It is up to the engineer to copy that text from the Terraform Cloud outputs to the application repository.
 
-**WIP**: This hasn't started yet.
+## Publish Lambda Container
+
+This is almost exactly the same as the Fargate workflows. The only difference is the inclusion of the name of the Lambda function itself.
+
+### lambda-shared-deploy-dev.yml and lambda-shared-deploy-stage.yml
+
+A sample caller workflow should look like
+
+```yaml
+jobs:
+  deploy:
+    name: <env> Deploy lambda Container
+    uses: mitlibraries/.github/.github/workflows/lambda-shared-deploy-<env>.yml@main
+    secrets: inherit
+    with:
+      AWS_REGION: "<aws_region>"
+      GHA_ROLE: "<name_of_iam_role_with_ecr_publish_permissions>"
+      ECR: "<name_of_ecr_repository>"
+      FUNCTION: "<name_of_lambda_function>"
+```
+
+### lambda-shared-promote-prod.yml
+
+This is almost exactly the same as for Fargate containers, just with the addition of the Lambda function name.
+
+A sample caller workflow would look like
+
+```yaml
+jobs:
+  deploy:
+    name: Prod Promote Lambda Container
+    uses: mitlibraries/.github/.github/workflows/lambda-shared-promote-prod.yml@main
+    secrets: inherit
+    with:
+      AWS_REGION: "<aws_region>"
+      GHA_ROLE_STAGE: "<name_of_iam_role_with_ecr_publish_permissions_in_stage>"
+      GHA_ROLE_PROD: "<name_of_iam_role_with_ecr_publish_permissions_in_prod>"
+      ECR_STAGE: "<name_of_ecr_repository_in_stage>"
+      ECR_PROD: "<name_of_ecr_repository_in_prod>"
+      FUNCTION: "<name_of_lambda_function_in_prod>"
+```
+
+### Additional Requirements/Dependencies
+
+It also depends on the appropriate infrastructure in place, particularly the OIDC configuration and IAM role for Github Actions to connect to AWS.
+
+**Note**: The caller workflows are generated by the Terraform code that creates the ECR and associated IAM Roles and permissions. It is up to the engineer to copy that text from the Terraform Cloud outputs to the application repository.

--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ Since we use a template repo for all our Terraform repos, we don't need starter 
 
 All these shared workflows have `tf-` as a prefix.
 
-
 ## Publish Fargate Container
 
 There are three workflows associated with publishing Docker containers. **Note**: The automated workflows deploy the updated container to the ECR repository, but the workflows **do not** force a container-based service to restart!
@@ -79,7 +78,7 @@ There are three workflows associated with publishing Docker containers. **Note**
 
 ### fargate-shared-deploy-dev.yml & fargate-shared-deploy-stage.yml
 
-These two workflows are almost exactly the same. They require 
+These two workflows are almost exactly the same. They require
 
 - shared secrets that exists in our MITLibraries GitHub Organization.
 - a caller workflow that passes certain values to the shared workflow
@@ -97,6 +96,17 @@ jobs:
       GHA_ROLE: "<name_of_iam_role_with_ecr_publish_permissions>"
       ECR: "<name_of_ecr_repository>"
 ```
+
+The container that is pushed to the AWS ECR Repository in Dev1 is tagged with
+
+- the short (8 character) SHA of the most recent commit on the feature branch that generated the PR
+- the PR number for the repo
+- the word "latest"
+
+The container that is pushed to the AWS ECR Repository in Stage-Workloads is tagged with
+
+- the short (8 character) SHA of the merge commit
+- the word "latest"
 
 ### fargate-shared-promote-prod.yml
 
@@ -118,6 +128,12 @@ jobs:
       ECR_PROD: "<name_of_ecr_repository_in_prod>"
 ```
 
+The container that is pushed to the AWS ECR Repository in Prod is tagged with
+
+- the short (8 character) SHA of the most recent commit on the feature branch that generated the PR
+- the release tag
+- the word "latest"
+
 ### Additional Requirements/Dependencies
 
 It also depends on the appropriate infrastructure in place, particularly the OIDC configuration and IAM role for Github Actions to connect to AWS.
@@ -126,7 +142,7 @@ It also depends on the appropriate infrastructure in place, particularly the OID
 
 ## Publish Lambda Container
 
-This is almost exactly the same as the Fargate workflows. The only difference is the inclusion of the name of the Lambda function itself.
+This is almost exactly the same as the Fargate workflows. The only difference is the inclusion of the name of the Lambda function itself. See the Fargate section above for full details.
 
 ### lambda-shared-deploy-dev.yml and lambda-shared-deploy-stage.yml
 


### PR DESCRIPTION
## Why these changes are being introduced

During the testing of the [docker-matomo](https://github.com/MITLibraries/docker-matomo) automated builds, the dev-build workflow [generated an error](https://github.com/MITLibraries/docker-matomo/actions/runs/2950396564) during the `docker build` step. The error indicated that the BuildKit needed to be enabled in order for it to succeed. 

The [Docker Build Enhancements](https://docs.docker.com/develop/develop-images/build_enhancements/) documentation indicated that the simplest way to enable the BuildKit is to prefix the `docker build` command with `DOCKER_BUILDKIT=1`.

At the same time, there was an InfraEng conversation regarding the way containers in ECR repos were getting tagged (the tags generated by the shared workflows in this repo were useless). This update also includes improved tagging of containers generated by caller workflows that use the Fargate and Lambda shared workflows here.

## How this addresses that need:
* Update each of the shared workflows that uses the `docker build` command by prefixing `DOCKER_BUILDKIT=1 `
* Update the README to correctly reflect the existing shared workflows for our Fargate and Lambda deployment automation
* Update the six workflows for Fargate and Lambda applications to generate more usable tags on the containers that are pushed to ECR

## How to verify/test

It is possible to use the updated shared workflows by changing the `@main` to `@docker-fixes` in the caller workflow commands. I have run tests with the docker-matomo repo in the [awsorg-cleanup branch](https://github.com/MITLibraries/docker-matomo/tree/awsorg-cleanup) for the dev automated container deployment: 
* [Action](https://github.com/MITLibraries/docker-matomo/actions/runs/2973047846)
* [line that shows good tags](https://github.com/MITLibraries/docker-matomo/runs/8139440503?check_suite_focus=true#step:4:151)


Side effects of this change:
None.
