### PR TITLE
Dependabot update

### DIFF
--- a/.github/workflows/fargate-shared-deploy-dev.yml
+++ b/.github/workflows/fargate-shared-deploy-dev.yml
@@ -23,6 +23,8 @@ jobs:
   deploy:
     name: Deploy build
     runs-on: ubuntu-latest
+    # This line adds a check for the "dependencies" label on a PR, and does NOT run the workflow if it is present
+    # That means that if you want this workflow to run on a dependabot PR, you need to remove the "dependencies" label it adds by default
     if: ${{ contains(github.event.pull_request.labels.*.name, 'dependencies') != false }}
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
     permissions:

--- a/.github/workflows/fargate-shared-deploy-dev.yml
+++ b/.github/workflows/fargate-shared-deploy-dev.yml
@@ -23,6 +23,7 @@ jobs:
   deploy:
     name: Deploy build
     runs-on: ubuntu-latest
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'dependencies') != false }}
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
     permissions:
       id-token: write

--- a/.github/workflows/lambda-shared-deploy-dev.yml
+++ b/.github/workflows/lambda-shared-deploy-dev.yml
@@ -26,6 +26,7 @@ jobs:
   deploy:
     name: Deploy build
     runs-on: ubuntu-latest
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'dependencies') != false }}
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
     permissions:
       id-token: write

--- a/.github/workflows/lambda-shared-deploy-dev.yml
+++ b/.github/workflows/lambda-shared-deploy-dev.yml
@@ -26,6 +26,8 @@ jobs:
   deploy:
     name: Deploy build
     runs-on: ubuntu-latest
+    # This line adds a check for the "dependencies" label on a PR, and does NOT run the workflow if it is present
+    # That means that if you want this workflow to run on a dependabot PR, you need to remove the "dependencies" label it adds by default
     if: ${{ contains(github.event.pull_request.labels.*.name, 'dependencies') != false }}
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
     permissions:

--- a/dependabot/README.md
+++ b/dependabot/README.md
@@ -1,0 +1,2 @@
+# This directory contains standard examples of dependabot configurations 
+# Each workflow should be appended by the type of workflow it is

--- a/dependabot/dependabot-pip.yml
+++ b/dependabot/dependabot-pip.yml
@@ -1,0 +1,18 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  # Maintain dependencies for npm
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/dependabot/dependabot-pip.yml
+++ b/dependabot/dependabot-pip.yml
@@ -3,6 +3,8 @@
 # Please see the documentation for all configuration options:
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 
+# This is an example of a python specific dependabot configuration
+
 version: 2
 updates:
   # Maintain dependencies for GitHub Actions


### PR DESCRIPTION
## Why these changes are being introduced
When we use dependabot, we dont want it to run our dev workflows that are triggered on PR's unless a human is present to do testing for the PR.  

## How this addresses that need:
* Add a check to the dev workflows that evaluates whether the PR is tagged with "dependencies" as a label. 
  * if it is, we dont run the dev actions
  * to run the actions, we can delete the label, and the workflow will run automatically
  * in repos where dependabot is not used, as long as dont have the "dependencies" tag on anything this check shouldn't affect any of our normal workflows. 
* Add a folder for example dependabot configurations 

## How to verify/test
To test, i copied the timdex-index-manager repo to my personal github account and tested with the branched workflows here.  Probably the best way to test is to make a similar copy yourself and enable dependabot, then edit the workflows and remove the tag after dependabot creates a PR.  I had to do testing outside of the organization so that i didn't accidentally mess up dev ECR we were using.  

## Side effects of this change
None