### PR TITLE
Modify check for dev actions to "triggering_actor" instead of label

### DIFF
--- a/.github/workflows/fargate-shared-deploy-dev.yml
+++ b/.github/workflows/fargate-shared-deploy-dev.yml
@@ -23,9 +23,8 @@ jobs:
   deploy:
     name: Deploy build
     runs-on: ubuntu-latest
-    # This line adds a check for the "dependencies" label on a PR, and does NOT run the workflow if it is present
-    # That means that if you want this workflow to run on a dependabot PR, you need to remove the "dependencies" label it adds by default
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'dependencies')}}
+    # This line adds a check for the user which is requesting the PR. As long as its not dependabot, we go ahead and run it. 
+    if: ${{ github.triggering_actor != 'dependabot[bot]' }}
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
     permissions:
       id-token: write

--- a/.github/workflows/lambda-shared-deploy-dev.yml
+++ b/.github/workflows/lambda-shared-deploy-dev.yml
@@ -26,9 +26,8 @@ jobs:
   deploy:
     name: Deploy build
     runs-on: ubuntu-latest
-    # This line adds a check for the "dependencies" label on a PR, and does NOT run the workflow if it is present
-    # That means that if you want this workflow to run on a dependabot PR, you need to remove the "dependencies" label it adds by default
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'dependencies')}}
+    # This line adds a check for the user which is requesting the PR. As long as its not dependabot, we go ahead and run it. 
+    if: ${{ github.triggering_actor != 'dependabot[bot]' }}
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
     permissions:
       id-token: write


### PR DESCRIPTION
This PR modifies the dev build workflows to look for the "triggering actor" instead of labels to know whether to run the workflow.  

With this change, dependabot PR's will not run automatically, but instead, will need to be triggered by a human, and labels will no longer need to changed.  

This doesn't seem well documented in github, but is described here - https://stackoverflow.com/questions/71679568/github-actions-ignore-or-exclude-dependabot-pull-requests