### PR TITLE
Update shared Python test workflow to use Make

### DIFF
--- a/.github/workflows/python-shared-test.yml
+++ b/.github/workflows/python-shared-test.yml
@@ -1,7 +1,7 @@
 # This workflow runs tests and sends a coverage report to Coveralls
-# Requirements: repo must contain a .python-version file, use pipenv for dependency
-# management, use the pytest framework for testing, and have coverage in its dev
-# dependencies.
+# Requirements: Calling repo must use pipenv for dependency management, contain a
+# .python-version file, and contain a Makefile with `make test` and `make coveralls`
+# commands.
 name: Python Shared Test Workflow
 
 on:
@@ -32,8 +32,8 @@ jobs:
 
       - name: Run tests and make coverage report
         run: |
-          pipenv run coverage run --source=. -m pytest
-          pipenv run coverage lcov -o ./coverage/lcov.info
+          make test
+          make coveralls
 
       - name: Coveralls
         uses: coverallsapp/github-action@master


### PR DESCRIPTION
### Why these changes are being introduced
Our shared Python test workflow previously hard-coded the pytest test commands. Using a `make test` command that can be defined within each calling repo will allow the repos to specify coverage directories, verbosity levels, and other options that may differ between different codebases.

### How this addresses that need
* Updates python-shared-test workflow to use `make test` and `make coveralls` commands instead of pytest and coveralls module commands.
* Updates the documented calling repo requirements to note that these two Make commands must be present.

### Side effects of this change
If there are any Python repos using this workflow that do not contain `make test` and `make coveralls` commands, their Github Actions runs will fail. Those commands are standard in most of our current Python repos, but it's possible we will encounter this and need to update one or two repos at some point.