### PR TITLE
Dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  # Weekly update schedule for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/fargate-shared-deploy-dev.yml
+++ b/.github/workflows/fargate-shared-deploy-dev.yml
@@ -31,7 +31,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/.github/workflows/fargate-shared-deploy-stage.yml
+++ b/.github/workflows/fargate-shared-deploy-stage.yml
@@ -29,7 +29,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/.github/workflows/fargate-shared-promote-prod.yml
+++ b/.github/workflows/fargate-shared-promote-prod.yml
@@ -36,7 +36,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       
       - name: Configure AWS credentials for Stage
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/lambda-shared-deploy-dev.yml
+++ b/.github/workflows/lambda-shared-deploy-dev.yml
@@ -34,7 +34,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/.github/workflows/lambda-shared-deploy-stage.yml
+++ b/.github/workflows/lambda-shared-deploy-stage.yml
@@ -32,7 +32,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/.github/workflows/lambda-shared-promote-prod.yml
+++ b/.github/workflows/lambda-shared-promote-prod.yml
@@ -39,7 +39,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       
       - name: Configure AWS credentials for Stage
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/python-shared-lint.yml
+++ b/.github/workflows/python-shared-lint.yml
@@ -19,7 +19,7 @@ jobs:
           echo "python_version=${python_version}" >> $GITHUB_ENV
 
       - name: Set up python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ env.python_version }}
           architecture: x64

--- a/.github/workflows/python-shared-test.yml
+++ b/.github/workflows/python-shared-test.yml
@@ -20,7 +20,7 @@ jobs:
           echo "python_version=${python_version}" >> $GITHUB_ENV
 
       - name: Set up python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ env.python_version }}
           architecture: x64

--- a/.github/workflows/ruby-shared-ci.yml
+++ b/.github/workflows/ruby-shared-ci.yml
@@ -8,9 +8,9 @@ jobs:
     name: Run Tests and Coverage
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
-      - uses: actions/cache@v1
+      - uses: actions/cache@v3
         with:
           path: vendor/bundle
           key: bundle-use-ruby-ubuntu-22.04-${{ hashFiles('.ruby-version') }}-${{ hashFiles('**/Gemfile.lock') }}

--- a/.github/workflows/tf-checkov-shared.yml
+++ b/.github/workflows/tf-checkov-shared.yml
@@ -13,11 +13,11 @@ jobs:
     name: run checkov
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v1
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Test with Checkov
         id: checkov
         uses: bridgecrewio/checkov-action@master

--- a/.github/workflows/tf-docs-gen-shared.yml
+++ b/.github/workflows/tf-docs-gen-shared.yml
@@ -10,12 +10,12 @@ jobs:
     name: terraform-docs
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         ref: ${{ github.event.pull_request.head.ref }}
 
     - name: Render terraform docs and push changes back to PR
-      uses: terraform-docs/gh-actions@main
+      uses: terraform-docs/gh-actions@v1.0.0
       with:
         working-dir: .
         output-file: README.md

--- a/.github/workflows/tf-validate-shared.yml
+++ b/.github/workflows/tf-validate-shared.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Terraform Setup
         uses: hashicorp/setup-terraform@v2


### PR DESCRIPTION
### Why these changes are being introduced

Caller workflows in other repos were reporting deprecation warnings for Node.js 12. These all pointed back to the fact that our shared workflows were using outdated versions of Actions from the GitHub Marketplace. 

### How this addresses that need

* Update actions/checkout to v3 (resolves Node.js 12 deprecation)
* Update actions/cache to v3
* Update actions/setup-python to v4 (resolves Node.js 12 deprecation)
* Update terraform-docs/gh-actions to v1

Additionally, this adds a dependabot configuration to this repo to force weekly dependency checks for the shared workflows stored here.

### Side effects of this change

Other than future PRs from Dependabot, there should be no side effects.
