### PR TITLE
Fix Conditional Syntax

### DIFF
--- a/.github/workflows/ecr-shared-deploy-stage.yml
+++ b/.github/workflows/ecr-shared-deploy-stage.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Get Python
         # Run the Python setup only when there is a .python-version file in the root
         # of the repository. Otherwise, this step is skipped.
-        if: ${{ env.python_repo = 1 }}
+        if: ${{ env.python_repo == 1 }}
         uses: actions/setup-python@v4
         with:
           architecture: x64
@@ -68,7 +68,7 @@ jobs:
       - name: Get Ruby
         # Run the Ruby setup setup only when there is a .ruby-version file in the 
         # root of the repository. Otherwise, this step is skipped.
-        if: ${{ env.ruby_repo = 1 }}
+        if: ${{ env.ruby_repo == 1 }}
         uses: ruby/setup-ruby@v1
 
       - name: Run pre-build steps


### PR DESCRIPTION
### Why these changes are being introduced

The wrong syntax was used for a conditional test in the shared workflow for deploying containers to stage. This was discovered after a test deploy to Stage for the Carbon app.

The correct syntax can be found at [learn-github-actions/expressions](https://docs.github.com/en/actions/learn-github-actions/expressions).

The mistake can be seen at [Carbon stage deploy action](https://github.com/MITLibraries/carbon/actions/runs/3331238125)

### How this addresses that need

* Replace "=" with "==" in the `if:` statement in the Python and Ruby version checks

### Side effects of this change

None.
