### PR TITLE
Automated Publishing to our AWS S3-based CDN

### DIFF
--- a/.github/workflows/cdn-shared-publish.yml
+++ b/.github/workflows/cdn-shared-publish.yml
@@ -33,6 +33,14 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: DEV Configure AWS credentials
+        # Only run this step if the environment is "dev"
+        if: ${{ inputs.ENVIRONMENT == 'dev' }}
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCT_DEV }}:role/${{ inputs.GHA_ROLE }}
+          aws-region: ${{ inputs.AWS_REGION }}
+
       - name: STAGE Configure AWS credentials
         # Only run this step if the environment is "stage"
         if: ${{ inputs.ENVIRONMENT == 'stage' }}
@@ -51,3 +59,6 @@ jobs:
 
       - name: Sync S3 content
         run: aws s3 sync . ${{ inputs.S3URI }} --delete --exclude ".github/*" --exclude ".git/*" --exclude ".gitignore" 
+
+      - name: Invalidate cache
+        run: aws cloudfront create-invalidation --distribution-id $(aws ssm get-parameter --name "/tfvars/libraries-website/cdnsite-id" --query 'Parameter.Value' --output text) --paths "/$(echo ${{ inputs.S3URI }} | awk -F/ '{print $4}')/*"

--- a/.github/workflows/cdn-shared-publish.yml
+++ b/.github/workflows/cdn-shared-publish.yml
@@ -1,0 +1,53 @@
+# Static Site Web Publishing to CDN
+name: Publish Static Site to CDN
+
+on:
+  workflow_call:
+    inputs:
+      AWS_REGION:
+        required: true
+        type: string
+      GHA_ROLE:
+        required: true
+        type: string
+      ENVIRONMENT:
+        required: true
+        type: string
+      S3URI:
+        required: true
+        type: string
+
+# Set defaults
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  publish:
+    name: Publish content to CDN
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: STAGE Configure AWS credentials
+        # Only run this step if the environment is "stage"
+        if: ${{ inputs.ENVIRONMENT == 'stage' }}
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCT_STAGE }}:role/${{ inputs.GHA_ROLE }}
+          aws-region: ${{ inputs.AWS_REGION }}
+
+      - name: PROD Configure AWS credentials
+        # Only run this step if the environment is "prod"
+        if: ${{ inputs.ENVIRONMENT == 'prod' }}
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCT_PROD }}:role/${{ inputs.GHA_ROLE }}
+          aws-region: ${{ inputs.AWS_REGION }}
+
+      - name: Sync S3 content
+        run: aws s3 sync . ${{ inputs.S3URI }} --delete --exclude ".github/*" --exclude ".git/*" --exclude ".gitignore" 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ That's it! Adding the shared workflow should now run the standard tests, code co
 
 You can (optionally) add this using a Starter Workflow by going to Actions in the repository you'd like it added to, and selecting the "MIT Libraries Ruby CI Workflow" which will allow you to open a PR to add this shared workflow.
 
-Requirements
+### Requirements
 
 - Add `simplecov` and `simplecov-lcov` to the test section of Gemfile
 - `bundle install`
@@ -158,7 +158,7 @@ It also depends on the appropriate infrastructure in place, particularly the OID
 
 ## Automated Publishing to CDN
 
-There are at least two static HTML repositories (future-of-libraries and oatf) that will benefit from automated publishing to the S3-based CDN in our AWS Organization. The publishing automation (for both stage & prod) is handled by one shared workflow, [cdn-shared-publish.yml](./.github/workflows/cdn-shared-publish.yml).
+There are at least two static HTML repositories (future-of-libraries and open-access-task-force) that will benefit from automated publishing to the S3-based CDN in our AWS Organization. The publishing automation (for both stage & prod) is handled by one shared workflow, [cdn-shared-publish.yml](./.github/workflows/cdn-shared-publish.yml).
 
 ### Requirements
 

--- a/README.md
+++ b/README.md
@@ -155,3 +155,18 @@ The container that is pushed to the AWS ECR Repository in Prod is tagged with
 ### Additional Requirements/Dependencies
 
 It also depends on the appropriate infrastructure in place, particularly the OIDC configuration and IAM role for Github Actions to connect to AWS. In most cases, this is handled by the [mitlib-tf-workloads-ecr](https://github.com/mitlibraries/mitlib-tf-workloads-ecr) repository (which also generates the GHA workflow files for each ECR repository).
+
+## Automated Publishing to CDN
+
+There are at least two static HTML repositories (future-of-libraries and oatf) that will benefit from automated publishing to the S3-based CDN in our AWS Organization. The publishing automation (for both stage & prod) is handled by one shared workflow, [cdn-shared-publish.yml](./.github/workflows/cdn-shared-publish.yml).
+
+### Requirements
+
+The following values must be passed in to the shared workflow from the caller workflow:
+
+- `AWS_REGION`: the region where the S3 bucket lives
+- `GHA_ROLE`: the OIDC role (managed by the [mitlib-tf-workloads-libraries-website](https://github.com/MITLibraries/mitlib-tf-workloads-libraries-website) repository)
+- `ENVIRONMENT`: either `stage` or `prod` (this workflow is not intended for the `dev` environment)
+- `S3URI`: the full S3 URI (including the path) where the files should be uploaded
+
+To make life easy for the web devs, the [mitlib-tf-workloads-libraries-website](https://github.com/MITLibraries/mitlib-tf-workloads-libraries-website) repository generates the correct caller workflow and stores it as a Terraform output in TfCloud.


### PR DESCRIPTION
### Why these changes are being introduced

We will have some repositories with "static" web content that will need to be published to our S3-based CDN in our AWS Organization. For now, we just have one ([future-of-libraries-static](https://github.com/mitlibraries/future-of-libraries-static)), but there will be more. The publishing of content from the repo to S3 can be handled via GitHub Actions, and it makes the most sense to build this automation as a shared workflow that can be invoked from other repos.

This workflow was tested. You can see the results in the [Actions tab](https://github.com/MITLibraries/future-of-libraries-static/actions/runs/3708414824) on the ([future-of-libraries-static](https://github.com/mitlibraries/future-of-libraries-static)) repository.

### How this addresses that need

* Create the `cdn-shared-publish.yml` workflow to sync repo files with folders in the S3 bucket

### Side effects of this change

No side effects. No dependency changes.

### Relevant ticket(s)

* https://mitlibraries.atlassian.net/browse/LM-93
