### PR TITLE
Add Option for Additional Ignored Folder

### DIFF
--- a/.github/workflows/cdn-shared-publish.yml
+++ b/.github/workflows/cdn-shared-publish.yml
@@ -16,7 +16,7 @@ on:
       S3URI:
         required: true
         type: string
-      EXCLUDE:
+      SYNC_PARAMS:
         required: false
         type: string
 
@@ -62,8 +62,8 @@ jobs:
 
       - name: Sync S3 content
         run: |
-          if [ '${{ inputs.EXCLUDE }}' != '' ]; then
-            aws s3 sync . ${{ inputs.S3URI }} --delete --exclude ".github/*" --exclude ".git/*" --exclude ".gitignore" --exclude "${{ inputs.EXCLUDE }}"
+          if [ '${{ inputs.SYNC_PARAMS }}' != '' ]; then
+            aws s3 sync . ${{ inputs.S3URI }} --delete --exclude ".github/*" --exclude ".git/*" --exclude ".gitignore" ${{ inputs.SYNC_PARAMS }}
           else
             aws s3 sync . ${{ inputs.S3URI }} --delete --exclude ".github/*" --exclude ".git/*" --exclude ".gitignore"
           fi

--- a/.github/workflows/cdn-shared-publish.yml
+++ b/.github/workflows/cdn-shared-publish.yml
@@ -16,6 +16,9 @@ on:
       S3URI:
         required: true
         type: string
+      EXCLUDE:
+        required: false
+        type: string
 
 # Set defaults
 defaults:
@@ -58,7 +61,12 @@ jobs:
           aws-region: ${{ inputs.AWS_REGION }}
 
       - name: Sync S3 content
-        run: aws s3 sync . ${{ inputs.S3URI }} --delete --exclude ".github/*" --exclude ".git/*" --exclude ".gitignore" 
+        run: |
+          if [ '${{ inputs.EXCLUDE }}' != '' ]; then
+            aws s3 sync . ${{ inputs.S3URI }} --delete --exclude ".github/*" --exclude ".git/*" --exclude ".gitignore" --exclude "${{ inputs.EXCLUDE }}"
+          else
+            aws s3 sync . ${{ inputs.S3URI }} --delete --exclude ".github/*" --exclude ".git/*" --exclude ".gitignore"
+          fi
 
       - name: Invalidate cache
         run: aws cloudfront create-invalidation --distribution-id $(aws ssm get-parameter --name "/tfvars/libraries-website/cdnsite-id" --query 'Parameter.Value' --output text) --paths "/$(echo ${{ inputs.S3URI }} | awk -F/ '{print $4}')/*"

--- a/README.md
+++ b/README.md
@@ -169,4 +169,8 @@ The following values must be passed in to the shared workflow from the caller wo
 - `ENVIRONMENT`: either `stage` or `prod` (this workflow is not intended for the `dev` environment)
 - `S3URI`: the full S3 URI (including the path) where the files should be uploaded
 
+There is one optional `with:` argument:
+
+- `SYNC_PARAMS`: this is a string that is appended to the `aws s3 sync` command. If nothing is passed from the caller workflow, it is ignored. This is intended to be used for adding additional `--exclude` arguments for any other files/folders in the web content repo that shouldn't be published to the S3 bucket for the site.
+
 To make life easy for the web devs, the [mitlib-tf-workloads-libraries-website](https://github.com/MITLibraries/mitlib-tf-workloads-libraries-website) repository generates the correct caller workflow and stores it as a Terraform output in TfCloud.


### PR DESCRIPTION
### Why these changes are being introduced

We need the ability to allow the web developer to optionally add an additional folder to the "exclude" list in the aws cli sync command. For example, this will allow for a documentation folder to be in the static site repo but not allow the contents of that folder to be synced to the website.

The changes here have been tested using the [future-of-libraries-static](https://github.com/MITLibraries/future-of-libraries-static) repo. The "dev" publishing workflow can be invoked manually, and it was tested twice, once with a value of `".docs/*"` passed to the shared workflow `EXCLUDE` input and once with nothing passed to the `EXCLUDE` input. The output from those two runs are available at the links below:

* [No value passed to the `EXCLUDE` variable](https://github.com/MITLibraries/future-of-libraries-static/actions/runs/3832485625/jobs/6522845274)
* [The `".docs/*"` value passed to the `EXCLUDE` variable](https://github.com/MITLibraries/future-of-libraries-static/actions/runs/3832477305/jobs/6522826280)

In both cases, go in to the workflow log and expand the "Sync S3 Content" step and expand the first line of that step to see the `if/then/else` statement that is executed.

The [future-of-libraries-static](https://github.com/MITLibraries/future-of-libraries-static) repo will get a PR after this one is approved and merged.


### How this addresses that need

* Add an optional workflow input ("EXCLUDE")
* Update the workflow sync step to use the additional EXCLUDE value if it is passed to this shared workflow


### Side effects of this change

None.


### Relevant ticket(s)

* https://mitlibraries.atlassian.net/browse/LM-118
* https://mitlibraries.atlassian.net/browse/LM-93


[LM-118]: https://mitlibraries.atlassian.net/browse/LM-118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ