### PR TITLE
Remove pipenv cache from ECR workflows

### DIFF
--- a/.github/workflows/ecr-shared-deploy-dev.yml
+++ b/.github/workflows/ecr-shared-deploy-dev.yml
@@ -82,7 +82,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           architecture: x64
-          cache: 'pipenv'
 
       - name: Get Ruby
         # Run the Ruby setup setup only when there is a .ruby-version file in the 

--- a/.github/workflows/ecr-shared-deploy-stage.yml
+++ b/.github/workflows/ecr-shared-deploy-stage.yml
@@ -63,7 +63,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           architecture: x64
-          cache: 'pipenv'
 
       - name: Get Ruby
         # Run the Ruby setup setup only when there is a .ruby-version file in the 


### PR DESCRIPTION
### Why these changes are being introduced

There is a known bug in `actions/setup-python` related to caching: https://github.com/actions/setup-python/issues/436 that we experienced with the first auto-deploy runs for the alma-creditcardslips application. As a quick fix, we simply remove the cache option for pipenv from the step and everything runs smoothly.

### How this addresses that need

Remove `cache: 'pipenv'` from the actions/setup-python for both the dev and stage ecr-shared-deploy- workflows.

The updated workflow was tested manually in the alma-creditcardslips application. The output of that run can be seen at https://github.com/MITLibraries/alma-creditcardslips/actions/runs/4206122678.


### Side effects of this change

None. Other than potentially slightly slower runs.

### Relevant ticket(s)

* [IN-735](https://mitlibraries.atlassian.net/browse/IN-735)


[IN-735]: https://mitlibraries.atlassian.net/browse/IN-735?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ