### PR TITLE
Update configure-aws-credentials to v2

### DIFF
--- a/.github/workflows/cdn-shared-publish.yml
+++ b/.github/workflows/cdn-shared-publish.yml
@@ -43,7 +43,7 @@ jobs:
       - name: DEV Configure AWS credentials
         # Only run this step if the environment is "dev"
         if: ${{ inputs.ENVIRONMENT == 'dev' }}
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCT_DEV }}:role/${{ inputs.GHA_ROLE }}
           aws-region: ${{ inputs.AWS_REGION }}
@@ -51,7 +51,7 @@ jobs:
       - name: STAGE Configure AWS credentials
         # Only run this step if the environment is "stage"
         if: ${{ inputs.ENVIRONMENT == 'stage' }}
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCT_STAGE }}:role/${{ inputs.GHA_ROLE }}
           aws-region: ${{ inputs.AWS_REGION }}
@@ -59,7 +59,7 @@ jobs:
       - name: PROD Configure AWS credentials
         # Only run this step if the environment is "prod"
         if: ${{ inputs.ENVIRONMENT == 'prod' }}
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCT_PROD }}:role/${{ inputs.GHA_ROLE }}
           aws-region: ${{ inputs.AWS_REGION }}

--- a/.github/workflows/ecr-shared-deploy-dev.yml
+++ b/.github/workflows/ecr-shared-deploy-dev.yml
@@ -53,7 +53,7 @@ jobs:
           fi
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCT_DEV }}:role/${{ inputs.GHA_ROLE }}
           aws-region: ${{ inputs.AWS_REGION }}

--- a/.github/workflows/ecr-shared-deploy-stage.yml
+++ b/.github/workflows/ecr-shared-deploy-stage.yml
@@ -51,7 +51,7 @@ jobs:
           fi
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCT_STAGE }}:role/${{ inputs.GHA_ROLE }}
           aws-region: ${{ inputs.AWS_REGION }}

--- a/.github/workflows/ecr-shared-promote-prod.yml
+++ b/.github/workflows/ecr-shared-promote-prod.yml
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/checkout@v3
       
       - name: Configure AWS credentials for Stage
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCT_STAGE }}:role/${{ inputs.GHA_ROLE_STAGE }}
           aws-region: ${{ inputs.AWS_REGION }}
@@ -63,7 +63,7 @@ jobs:
           docker tag ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR_STAGE }}:latest ${{ secrets.AWS_ACCT_PROD }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR_PROD }}:`echo ${{ env.tag_release }}`
 
       - name: Configure AWS credentials for Prod
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCT_PROD }}:role/${{ inputs.GHA_ROLE_PROD }}
           aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/fargate-shared-deploy-dev.yml
+++ b/.github/workflows/fargate-shared-deploy-dev.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCT_DEV }}:role/${{ inputs.GHA_ROLE }}
           aws-region: ${{ inputs.AWS_REGION }}

--- a/.github/workflows/fargate-shared-deploy-stage.yml
+++ b/.github/workflows/fargate-shared-deploy-stage.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCT_STAGE }}:role/${{ inputs.GHA_ROLE }}
           aws-region: ${{ inputs.AWS_REGION }}

--- a/.github/workflows/fargate-shared-promote-prod.yml
+++ b/.github/workflows/fargate-shared-promote-prod.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v3
       
       - name: Configure AWS credentials for Stage
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCT_STAGE }}:role/${{ inputs.GHA_ROLE_STAGE }}
           aws-region: ${{ inputs.AWS_REGION }}
@@ -61,7 +61,7 @@ jobs:
           docker tag ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR_STAGE }}:latest ${{ secrets.AWS_ACCT_PROD }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR_PROD }}:`echo $TAG_RELEASE`
 
       - name: Configure AWS credentials for Prod
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCT_PROD }}:role/${{ inputs.GHA_ROLE_PROD }}
           aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/lambda-shared-deploy-dev.yml
+++ b/.github/workflows/lambda-shared-deploy-dev.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCT_DEV }}:role/${{ inputs.GHA_ROLE }}
           aws-region: ${{ inputs.AWS_REGION }}

--- a/.github/workflows/lambda-shared-deploy-stage.yml
+++ b/.github/workflows/lambda-shared-deploy-stage.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCT_STAGE }}:role/${{ inputs.GHA_ROLE }}
           aws-region: ${{ inputs.AWS_REGION }}

--- a/.github/workflows/lambda-shared-promote-prod.yml
+++ b/.github/workflows/lambda-shared-promote-prod.yml
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/checkout@v3
       
       - name: Configure AWS credentials for Stage
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCT_STAGE }}:role/${{ inputs.GHA_ROLE_STAGE }}
           aws-region: ${{ inputs.AWS_REGION }}
@@ -64,7 +64,7 @@ jobs:
           docker tag ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR_STAGE }}:latest ${{ secrets.AWS_ACCT_PROD }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR_PROD }}:`echo $TAG_RELEASE`
 
       - name: Configure AWS credentials for Prod
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCT_PROD }}:role/${{ inputs.GHA_ROLE_PROD }}
           aws-region: ${{ env.AWS_REGION }}


### PR DESCRIPTION
### Why these changes are being introduced

The aws-actions/configure-aws-credentials GitHub Action finally has an updated release that defaults to Node16 instead of Node12.

### How this addresses that need

* Update all `uses: ` statements for the aws-actions/configure-aws-credentials Action to use the `v2` tag for the latest release

### Side effects of this change

No side effects

### Relevant ticket(s)

Resolves: #24 (GH issue)
