### PR TITLE
Publish Lambda@Edge Shared Workflow

### DIFF
--- a/.github/workflows/cf-lambda-shared-deploy.yml
+++ b/.github/workflows/cf-lambda-shared-deploy.yml
@@ -8,24 +8,20 @@ on:
       AWS_REGION:
         required: true
         type: string
-      GHA_ROLE:
-        required: true
-        type: string
       ENVIRONMENT:
         required: true
         type: string
-      UPLOAD_ZIP:
-        required: false
-        type: boolean
-        default: false
-      ZIP_FILE_NAME:
-        required: false
-        type: string
-        default: some_file_name
-      TF_WORKSPACE:
+      GHA_ROLE:
         required: true
         type: string
       TF_AUTO_APPLY:
+        required: false
+        type: boolean
+        default: false
+      TF_WORKSPACE:
+        required: true
+        type: string
+      UPLOAD_ZIP:
         required: false
         type: boolean
         default: false
@@ -36,9 +32,7 @@ defaults:
     shell: bash
 
 ## Add shared Environment Variables across jobs here ##
-env:
-  TF_CLOUD_ORGANIZATION: "${{ vars.TF_CLOUD_ORGANIZATION }}"
-  TF_API_TOKEN: "${{ secrets.TF_API_TOKEN }}"
+
 
 jobs:
   upload-zip:
@@ -46,7 +40,6 @@ jobs:
     if: ${{ inputs.UPLOAD_ZIP && github.triggering_actor != 'dependabot[bot]' }}
     name: Zip code and upload to S3
     runs-on: ubuntu-latest
-    # This line adds a check for the user which is requesting the PR. As long as its not dependabot, we go ahead and run it. 
     permissions:
       id-token: write
       contents: read
@@ -77,24 +70,29 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCT_PROD }}:role/${{ inputs.GHA_ROLE }}
           aws-region: ${{ inputs.AWS_REGION }}
-      
-      # Then we actually zip the file and upload it to the shared-files folder
-      - name: Zip files
-        run: zip -j ${{ inputs.ZIP_FILE_NAME }}.py.zip lambdas/*
+
+      # Create the zip per the Makefile create-zip command
+      - name: Package code into Zip
+        run: make create-zip
+
+      # Upload the .zip per the Makefile upload-zip command
       - name: Upload zip file
-        run: aws s3api put-object --bucket shared-files-$(aws sts get-caller-identity --query Account --output text) --body ${{ inputs.ZIP_FILE_NAME }}.py.zip --key files/${{ inputs.ZIP_FILE_NAME }}.py.zip
+        run: make upload-zip
 
   terraform-cloud-plan-apply:
     needs: upload-zip
+    env:
+      TF_CLOUD_ORGANIZATION: "${{ vars.TF_CLOUD_ORGANIZATION }}"
+      TF_API_TOKEN: "${{ secrets.TF_API_TOKEN }}"
     # Only run if the caller workflow is NOT from dependabot, and wait until the previous job is either completed or skipped
     if: ${{ github.triggering_actor != 'dependabot[bot]' && always() && !failure() && !cancelled() }}
-    name: Terraform Cloud Plan and maybe Apply
+    name: TfC Plan and (maybe) Apply
     runs-on: ubuntu-latest
     steps:
       - uses: hashicorp/tfc-workflows-github/actions/create-run@v1.1.1
         id: plan
         with:
-          message: "Triggered from Lambda application repo"
+          message: "Triggered from ${{ github.repository }}"
           workspace: ${{ inputs.TF_WORKSPACE }}
 
       - uses: hashicorp/tfc-workflows-github/actions/apply-run@v1.1.1

--- a/.github/workflows/cf-lambda-shared-deploy.yml
+++ b/.github/workflows/cf-lambda-shared-deploy.yml
@@ -1,0 +1,105 @@
+# Shared workflow for publishing Lambda@Edge functions to
+# CloudFront distributions
+name: Zip Lambda and Redeploy Distribution
+
+on:
+  workflow_call:
+    inputs:
+      AWS_REGION:
+        required: true
+        type: string
+      GHA_ROLE:
+        required: true
+        type: string
+      ENVIRONMENT:
+        required: true
+        type: string
+      UPLOAD_ZIP:
+        required: false
+        type: boolean
+        default: false
+      ZIP_FILE_NAME:
+        required: false
+        type: string
+        default: some_file_name
+      TF_WORKSPACE:
+        required: true
+        type: string
+      TF_AUTO_APPLY:
+        required: false
+        type: boolean
+        default: false
+
+# Set defaults
+defaults:
+  run:
+    shell: bash
+
+## Add shared Environment Variables across jobs here ##
+env:
+  TF_CLOUD_ORGANIZATION: "${{ vars.TF_CLOUD_ORGANIZATION }}"
+  TF_API_TOKEN: "${{ secrets.TF_API_TOKEN }}"
+
+jobs:
+  upload-zip:
+    # Only run if the caller workflow set UPLOAD_ZIP to `true` and the call is NOT from dependabot
+    if: ${{ inputs.UPLOAD_ZIP && github.triggering_actor != 'dependabot[bot]' }}
+    name: Zip code and upload to S3
+    runs-on: ubuntu-latest
+    # This line adds a check for the user which is requesting the PR. As long as its not dependabot, we go ahead and run it. 
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      # First we authenticate to AWS account, based on the ENVIRONMENT input
+      - uses: actions/checkout@v3
+      - name: DEV Configure AWS credentials
+        # Only run this step if the environment is "dev"
+        if: ${{ inputs.ENVIRONMENT == 'dev' }}
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCT_DEV }}:role/${{ inputs.GHA_ROLE }}
+          aws-region: ${{ inputs.AWS_REGION }}
+
+      - name: STAGE Configure AWS credentials
+        # Only run this step if the environment is "stage"
+        if: ${{ inputs.ENVIRONMENT == 'stage' }}
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCT_STAGE }}:role/${{ inputs.GHA_ROLE }}
+          aws-region: ${{ inputs.AWS_REGION }}
+    
+      - name: PROD Configure AWS credentials
+        # Only run this step if the environment is "prod"
+        if: ${{ inputs.ENVIRONMENT == 'prod' }}
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCT_PROD }}:role/${{ inputs.GHA_ROLE }}
+          aws-region: ${{ inputs.AWS_REGION }}
+      
+      # Then we actually zip the file and upload it to the shared-files folder
+      - name: Zip files
+        run: zip -j ${{ inputs.ZIP_FILE_NAME }}.py.zip lambdas/*
+      - name: Upload zip file
+        run: aws s3api put-object --bucket shared-files-$(aws sts get-caller-identity --query Account --output text) --body ${{ inputs.ZIP_FILE_NAME }}.py.zip --key files/${{ inputs.ZIP_FILE_NAME }}.py.zip
+
+  terraform-cloud-plan-apply:
+    needs: upload-zip
+    # Only run if the caller workflow is NOT from dependabot, and wait until the previous job is either completed or skipped
+    if: ${{ github.triggering_actor != 'dependabot[bot]' && always() && !failure() && !cancelled() }}
+    name: Terraform Cloud Plan and maybe Apply
+    runs-on: ubuntu-latest
+    steps:
+      - uses: hashicorp/tfc-workflows-github/actions/create-run@v1.1.1
+        id: plan
+        with:
+          message: "Triggered from Lambda application repo"
+          workspace: ${{ inputs.TF_WORKSPACE }}
+
+      - uses: hashicorp/tfc-workflows-github/actions/apply-run@v1.1.1
+        id: apply
+        if: ${{ fromJSON(steps.plan.outputs.payload).data.attributes.actions.IsConfirmable && inputs.TF_AUTO_APPLY }}
+        with:
+          run: ${{ steps.plan.outputs.run_id }}
+          comment: "Apply Run from GitHub Actions CI ${{ github.sha }}"

--- a/README.md
+++ b/README.md
@@ -195,12 +195,15 @@ There are multiple Lambda@Edge functions in our CloudFront distributions. The La
 
 ### Requirements
 
-- `AWS_REGION`: The region where the S3 bucket lives
-- `GHA_ROLE`: The OIDC role (managed by the [mitlib-tf-workloads-libraries-website](https://github.com/MITLibraries/mitlib-tf-workloads-libraries-website) repository)
-- `ENVIRONMENT`: One of `dev`, `stage`, or `prod`
-- `UPLOAD_ZIP` (*boolean*): A flag determining whether the zip and upload job should execute or not
-- `ZIP_FILE_NAME`: The name (without any extentsion) of the file that will appear in S3 shared-files bucket
-- `TF_WORKSPACE`: The name of the Terraform Cloud Workspace to which GHA should connect
-- `TF_AUTO_APPLY` (*boolean*): A boolean for whether the triggered plan should also be auto-applied (defaults to `false`)
+(in alphabetical order)
+
+- `AWS_REGION` (*string*, **required**): The region where the S3 bucket lives
+- `ENVIRONMENT` (*string*, **required**): One of `dev`, `stage`, or `prod`
+- `GHA_ROLE` (*string*, **required**): The OIDC role (managed by the [mitlib-tf-workloads-libraries-website](https://github.com/MITLibraries/mitlib-tf-workloads-libraries-website) repository)
+- `TF_AUTO_APPLY` (*boolean*, **optional**): (default == `false`) A boolean for whether the triggered plan should also be auto-applied. Setting this to `true` means that the TfC plan, if successful, will be automatically applied with no human interaction.
+- `TF_WORKSPACE` (*string*, **required**): The name of the Terraform Cloud Workspace to which GHA should connect
+- `UPLOAD_ZIP` (*boolean*, **optional**): (default == `false`) A flag determining whether the zip and upload job should execute or not. Setting this to `true` will force the application packaging and upload to S3 to happen before re-applying the Terraform code in TfC.
+
+**Note**: There is a hard dependency on the caller repo having a `Makefile` and having both `create-zip` and `upload-zip` as `make` commands for this workflow to function properly.
 
 To make life easy for the application developers, the [mitlib-tf-workloads-libraries-website](https://github.com/MITLibraries/mitlib-tf-workloads-libraries-website) repository generates the correct caller workflow for the Lambda application repos and stores it as a Terraform output in TfCloud. This can be copy/pasted into the repository containing the app to be deployed to the CloudFront distribution.

--- a/README.md
+++ b/README.md
@@ -188,3 +188,19 @@ There are two optional `with:` arguments:
   - The fixed behavior of this workflow is to ignore the `.gitignore` file, the `.git` directory, and the `.github` directory.
 
 To make life easy for the web devs, the [mitlib-tf-workloads-libraries-website](https://github.com/MITLibraries/mitlib-tf-workloads-libraries-website) repository generates the correct caller workflow for the custom domain sites and stores it as a Terraform output in TfCloud. This can be copy/pasted into the repository containing the content to be published to the CDN.
+
+## Automated Lambda@Edge Deployments
+
+There are multiple Lambda@Edge functions in our CloudFront distributions. The Lambda update & deployment as well as the CloudFront re-deployment (via Terraform) are centralized here to make it easier to add additional Lambda functions in the future. See [cf-lambda-deploy.yml](./.github/workflows/cf-lambda-shared-deploy.yml) for the actual workflow. See [Lambda@Edge CloudFront Deployment Model](https://mitlibraries.atlassian.net/l/cp/SP3QNj1s) for an overview of the deployment process.
+
+### Requirements
+
+- `AWS_REGION`: The region where the S3 bucket lives
+- `GHA_ROLE`: The OIDC role (managed by the [mitlib-tf-workloads-libraries-website](https://github.com/MITLibraries/mitlib-tf-workloads-libraries-website) repository)
+- `ENVIRONMENT`: One of `dev`, `stage`, or `prod`
+- `UPLOAD_ZIP` (*boolean*): A flag determining whether the zip and upload job should execute or not
+- `ZIP_FILE_NAME`: The name (without any extentsion) of the file that will appear in S3 shared-files bucket
+- `TF_WORKSPACE`: The name of the Terraform Cloud Workspace to which GHA should connect
+- `TF_AUTO_APPLY` (*boolean*): A boolean for whether the triggered plan should also be auto-applied (defaults to `false`)
+
+To make life easy for the application developers, the [mitlib-tf-workloads-libraries-website](https://github.com/MITLibraries/mitlib-tf-workloads-libraries-website) repository generates the correct caller workflow for the Lambda application repos and stores it as a Terraform output in TfCloud. This can be copy/pasted into the repository containing the app to be deployed to the CloudFront distribution.


### PR DESCRIPTION
### Why these changes are being introduced

As part of the GDT project we determined that we need a better way to manage the deployment of Lambda@Edge functions in our CloudFront distribution. Since we will have more than one application repository building Lambda functions for Lambda@Edge, it made the most sense to create a shared workflow here that can be called from multiple application repositories. The overview of the workflow is at [Lambda@Edge CloudFront Deployment Model](https://mitlibraries.atlassian.net/l/cp/fJZhzHFq).

### How this addresses that need

* Update the README with additional information about the new workflow
* Add a new workflow, cf-lambda-shared-deploy.yml, that runs all the steps to push a .zip of the application code for the Lambda function to the shared-files deployment bucket in AWS and then triggers a re-run of the appropriate workspace in Terraform Cloud.

### How to review these changes

Shared workflows can only be run when called from another repository. The workflow in question here has been executed multiple times from the [cf-lambda-custom-domain](https://github.com/MITLibraries/cf-lambda-custom-domain) repository with different values. (Some of those runs didn't work quite as expected so there were a few iterations of the shared workflow that, once worked out, got squashed into the single commit in this PR.) 
* Good run: https://github.com/MITLibraries/cf-lambda-custom-domain/actions/runs/7425693304

It is possible to test this shared workflow by modifying either [dev-cf-deploy-lambda.yml](https://github.com/MITLibraries/cf-lambda-custom-domain/blob/initialize-workflows/.github/workflows/dev-cf-deploy-lambda.yml) or [dev-cf-redeploy-only.yml](https://github.com/MITLibraries/cf-lambda-custom-domain/blob/initialize-workflows/.github/workflows/dev-cf-redeploy-only.yml) in the `initialize-workflows` branch in that repository and then manually trigger the workflow in that branch from that repository (that's how all the runs in the [Actions](https://github.com/MITLibraries/cf-lambda-custom-domain/actions) tab in that repo were generated.

See (cf-lambda-custom-domain PR#2)[https://github.com/MITLibraries/cf-lambda-custom-domain/pull/2] for the caller workflows that will use this shared workflow.

### Side effects of this change

None.

### Relevant ticket(s)

* [GDT-97](https://mitlibraries.atlassian.net/browse/GDT-97)


[GDT-97]: https://mitlibraries.atlassian.net/browse/GDT-97?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ