### PR TITLE
Update Terraform Shared Workflows

### DIFF
--- a/.github/workflows/tf-checkov-shared.yml
+++ b/.github/workflows/tf-checkov-shared.yml
@@ -14,10 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.9
+
       - name: Test with Checkov
         id: checkov
         uses: bridgecrewio/checkov-action@master

--- a/.github/workflows/tf-docs-shared.yml
+++ b/.github/workflows/tf-docs-shared.yml
@@ -1,0 +1,25 @@
+# This action runs depends on configured pre-commit settings in
+# the caller workflow. It runs just one hook: terraform-docs and
+# passes if there are no changes or fails if it detects changes
+# to write to the README files. This should always pass if the 
+# developer of the caller repo is using the pre-commit hooks.
+
+name: Check terraform-docs
+
+on:
+  workflow_call:
+
+jobs:
+  docs:
+    name: terraform-docs
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.head.ref }}
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+    - uses: pre-commit/action@v3.0.1
+      with:
+        extra_args: terraform-docs-go --all-files

--- a/.github/workflows/tf-validate-shared.yml
+++ b/.github/workflows/tf-validate-shared.yml
@@ -9,7 +9,7 @@ defaults:
 
 jobs:
   validate-terraform:
-    name: Check with a terraform fmt
+    name: terraform fmt & validate
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
### Why these changes are being introduced

InfraEng is moving toward using `pre-commit` to help with linting/checking our code in our local environments. This is partly due to the lack of support for the `terraform-docs` GitHub Action. Since our Terraform repos will have `pre-commit` configured, it makes sense to leverage that to handle the `terraform-docs` check that the README files in our Terraform repos are up-to-date.

### How this addresses that need

* Add a new shared workflow to run `terraform-docs` via the `pre-commit` configuration that will be in our Terraform repositories
* Remove the unneeded Python install in the `checkov` shared workflow (now that it's container based, we no longer need to load a version of Python)
* Minor cleanup of the name of a job in one of the Terraform shared workflows

### Side effects of this change

None.

### Relevant ticket(s)

See [mitlib-tf-workloads-init PR#36](https://github.com/MITLibraries/mitlib-tf-workloads-init/pull/36) for details.
