### PR TITLE
IN-991: Guardrail for tagged releases for production deploys

### DIFF
--- a/.github/workflows/cf-lambda-shared-deploy.yml
+++ b/.github/workflows/cf-lambda-shared-deploy.yml
@@ -89,13 +89,13 @@ jobs:
     name: TfC Plan and (maybe) Apply
     runs-on: ubuntu-latest
     steps:
-      - uses: hashicorp/tfc-workflows-github/actions/create-run@v1.1.1
+      - uses: hashicorp/tfc-workflows-github/actions/create-run@v1.3.0
         id: plan
         with:
           message: "Triggered from ${{ github.repository }}"
           workspace: ${{ inputs.TF_WORKSPACE }}
 
-      - uses: hashicorp/tfc-workflows-github/actions/apply-run@v1.1.1
+      - uses: hashicorp/tfc-workflows-github/actions/apply-run@v1.3.0
         id: apply
         if: ${{ fromJSON(steps.plan.outputs.payload).data.attributes.actions.IsConfirmable && inputs.TF_AUTO_APPLY }}
         with:

--- a/.github/workflows/ecr-shared-promote-prod.yml
+++ b/.github/workflows/ecr-shared-promote-prod.yml
@@ -23,6 +23,8 @@ on:
         required: false
         type: string
 
+permissions: read-all
+
 # Set defaults
 defaults:
   run:
@@ -30,6 +32,7 @@ defaults:
 
 jobs:
   deploy:
+    if: ${{ github.ref == 'refs/heads/main' || github.event.release.target_commitish == 'main' }}
     name: Promote Build to Prod
     # Download from Stage then upload to Prod
     runs-on: ubuntu-latest

--- a/.github/workflows/tf-docs-gen-shared.yml
+++ b/.github/workflows/tf-docs-gen-shared.yml
@@ -15,7 +15,7 @@ jobs:
         ref: ${{ github.event.pull_request.head.ref }}
 
     - name: Render terraform docs and push changes back to PR
-      uses: terraform-docs/gh-actions@v1.0.0
+      uses: terraform-docs/gh-actions@v1.1.0
       with:
         working-dir: .
         output-file: README.md

--- a/README.md
+++ b/README.md
@@ -128,6 +128,14 @@ The container that is pushed to the AWS ECR Repository in Stage-Workloads is tag
 
 The automated deploys to dev & stage actually build the container through GitHub Actions. The promote to prod workflow just copies the container from stage to prod to ensure that there is no difference at all in what is deployed.
 
+The caller workflows for this shared workflow are configured with `on.workflow_dispatch` and `on.release.types: [published]`. The former is for manual deploys from the GitHub UI and the latter is for deploying to production when a new release tag is issued. But, we want to ensure that only tagged releases on the `main` branch of the calling repository will trigger a run (we don't want a published tag on a feature branch to unintentionally push something to Production). So, we add a conditional for the `job.deploy` that checks the calling branch:
+
+```yaml
+    if: ${{ github.ref == 'refs/heads/main' || github.event.release.target_commitish == 'main' }}
+```
+
+The `github.ref` value gets set when the trigger is a release tag. The `github.event.release.target_commitish` value gets set when the trigger is `workflow_dispatch`.
+
 A sample caller workflow would look like
 
 ```yaml


### PR DESCRIPTION
### Why these changes are being introduced

* The shared workflow for publishing a container to Prod-Workloads did not have any protection for tags that were put on branches other than the `main` branch. So, it was possible that if someone published a tagged release on a branch other than the `main` branch, that feature branch could have been deployed to Prod-Workloads.
* Dependabot flagged two Terraform-related dependencies to update

### How this addresses that need

* The `ecr-shared-promote-prod.yml` workflow now has a conditional on the job that checks the source branch. If the source branch is anything other than `main`, the shared workflow will not run. The conditional checks two different  environment values, `github.ref` and `github.event.release.target_commitish`, since one value only exists if the initial trigger was `on.release` and one value only exists if the initial trigger was `workflow_dispatch`.
* The two dependabot-flagged dependencies were update to the new releases.

I ran tests of this in a couple of personal repositories. The results of those tests can be found at

* [Actions](https://github.com/cabutlermit/git-flow-test/actions): See all the Actions that ran on 5/15/2024

### Side effects of this change

None.

### Relevant ticket(s)

* https://mitlibraries.atlassian.net/browse/IN-991

Resolves: #41 
