### PR TITLE
Additional Logic for Prod Promote

### DIFF
--- a/.github/workflows/ecr-shared-promote-prod.yml
+++ b/.github/workflows/ecr-shared-promote-prod.yml
@@ -50,14 +50,29 @@ jobs:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCT_STAGE }}:role/${{ inputs.GHA_ROLE_STAGE }}
           aws-region: ${{ inputs.AWS_REGION }}
 
+      - name: Check SHAs
+        id: check_sha
+        run: |
+          export HEAD_SHA=$(git rev-parse --short=8 HEAD)
+          export ECR_SHA=$(aws ecr describe-images --repository-name ${{ inputs.ECR_STAGE }} --image-ids imageTag=latest --query 'imageDetails[].imageTags' | sed -E 's/[^a-zA-Z0-9]/\n/g' | grep -E '^[a-f0-9]{8}$')
+          if [[ $HEAD_SHA == $ECR_SHA ]]; then
+            echo "sha_match=true" >> $GITHUB_ENV
+          else
+            echo "sha_match=false" >> $GITHUB_ENV
+            echo "FAILURE: Stage-Workloads SHA did not match the main branch." >> $GITHUB_STEP_SUMMARY
+            exit 1
+          fi
+
       - name: Create tags
         # Capture the Release tag to attach to the uploaded container in AWS
+        if: ${{ env.sha_match == 'true' }}
         id: tags
         run: |
           echo "tag_sha=$GITHUB_SHA" >> $GITHUB_ENV
           echo "tag_release=${{ github.event.release.tag_name }}" >> $GITHUB_ENV
 
       - name: Download from Stage and re-tag
+        if: ${{ env.sha_match == 'true' }}
         run: |
           docker login -u AWS -p $(aws ecr get-login-password --region ${{ inputs.AWS_REGION }}) ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com
           docker pull ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR_STAGE }}:latest
@@ -66,12 +81,14 @@ jobs:
           docker tag ${{ secrets.AWS_ACCT_STAGE }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR_STAGE }}:latest ${{ secrets.AWS_ACCT_PROD }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR_PROD }}:`echo ${{ env.tag_release }}`
 
       - name: Configure AWS credentials for Prod
+        if: ${{ env.sha_match == 'true' }}
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCT_PROD }}:role/${{ inputs.GHA_ROLE_PROD }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Upload container to Prod
+        if: ${{ env.sha_match == 'true' }}
         run: |
           docker login -u AWS -p $(aws ecr get-login-password --region ${{ inputs.AWS_REGION }}) ${{ secrets.AWS_ACCT_PROD }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com
           docker push ${{ secrets.AWS_ACCT_PROD }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR_PROD }}:latest
@@ -80,5 +97,5 @@ jobs:
 
       - name: Update Lambda Function in Prod
         # Only update the Lambda Function if the container is destined for Lambda
-        if: ${{ inputs.FUNCTION != '' }}
+        if: ${{ inputs.FUNCTION != '' && env.sha_match == 'true' }}
         run: aws lambda update-function-code --function-name ${{ inputs.FUNCTION }} --image-uri ${{ secrets.AWS_ACCT_PROD }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR_PROD }}:latest --query "LastUpdateStatusReasonCode" --output text

--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ The caller workflows for this shared workflow are configured with `on.workflow_d
 
 The `github.ref` value gets set when the trigger is a release tag. The `github.event.release.target_commitish` value gets set when the trigger is `workflow_dispatch`.
 
+Additionally, we need to ensure that the container in the Stage-Workloads ECR repository is from the merge commit on `main`. (Since it is allowable for a developer to manually run the GitHub Actions Workflow to push a feature branch container to Stage-Workloads, we need to include this verification.) In essence, we are checking that the 8-character SHA tag on the container image in ECR matches the 8-character SHA for the merge commit into `main`.
+
 A sample caller workflow would look like
 
 ```yaml
@@ -156,8 +158,8 @@ There is one optional `with:` argument: `FUNCTION: "${function}"` in the situati
 
 The container that is pushed to the AWS ECR Repository in Prod is tagged with
 
-- the short (8 character) SHA of the most recent commit on the feature branch that generated the PR
-- the release tag
+- the short (8 character) SHA of the tagged merge commit
+- the release tag name
 - the word "latest"
 
 ### Additional Requirements/Dependencies


### PR DESCRIPTION
### Why these changes are being introduced

In the last PR, a scenario was proposed that showed it was possible for the wrong container to be deployed to Production. The changes here are an attempt to prevent that scenario from happening by adding an additional check to the prod-promote shared workflow. 

Thanks to @ghukill  for the initial seed for this solution (he asked, "is it possible to compare the commit SHA with the tag on the container in ECR in Stage-Workloads?"). 

Thanks are also due to ChatGPT for quickly providing the correct `sed` and `grep` piping to capture the SHA tag (which, to be clear, were fully tested to verify that it was valid answer).

### How this addresses that need

Add a check to the ecr-shared-prod-promote workflow that compares the 8-character SHA of the HEAD commit on the `main` branch to the SHA tag on the container in Stage-Workloads. If those two values match, the workflow will continue running; if those two values don't match, the workflow will fail with a notice to the GitHub Actions UI.

The `export ECR_SHA=...` line reaches out to Stage-Workloads ECR and captures all the tags on the container image that has the `latest` tag. The `sed` and `grep` pipelined commands find the tag that is just the 8-character SHA (and skips over any other tags). 

If the comparison of SHAs fails, the step will fail with a non-zero exit code, report the failure to the GitHub web UI Actions interface, and then fail the whole job. This does mean that the `if: ${{ env.sha_match == 'true' }}` lines for each of the other steps are actually redundant, but better to be safe than sorry!

### Side effects of this change

None.

### Relevant ticket(s)

* https://mitlibraries.atlassian.net/browse/IN-992
