### PR TITLE
allow graceful failure for push to coveralls.io

### DIFF
--- a/.github/workflows/python-shared-test.yml
+++ b/.github/workflows/python-shared-test.yml
@@ -39,3 +39,4 @@ jobs:
         uses: coverallsapp/github-action@v2.3.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          fail-on-error: false


### PR DESCRIPTION
### Why these changes are being introduced

Coveralls.io API endpoint is down, preventing normal CI operations in Github for shared workflows that push to coveralls.io.

### How this addresses that need

This PR would add a configuration option to the shared python project testing workflow when we attempt to push test coverage results to coveralls.io.

Coveralls.io was experiencing downtime, and they had [this information in their status page](https://status.coveralls.io/?utm_source=embed):

---

Update - Use "fail on error" to keep Coveralls 4xx from failing your CI builds / holding up your PRs:

While our API is in maintenance mode, new coverage report uploads (POSTs to /api/v1/jobs) will fail with a 405 or other 4xx error.

To keep this from breaking your CI builds and holding up your PRs, allow coveralls steps to "fail on error."

If you are using one of our Official Integrations, add: 

- `fail-on-error: false` if using Coveralls GitHub Action
- `fail_on_error: false` if using Coveralls Orb for CircleCI
- `--no-fail` flag if using Coveralls Coverage Reporter directly

Documentation:
- Official Integrations: https://docs.coveralls.io/integrations#official-integrations
- Coveralls GitHub Action: https://github.com/marketplace/actions/coveralls-github-action
- Coveralls Orb for CircleCI: https://circleci.com/developer/orbs/orb/coveralls/coveralls
- Coveralls Coverage Reporter: https://github.com/coverallsapp/coverage-reporter

---

### Side effects of this change

If coveralls push fails, a build will continue, but we may not be aware of the coverage push failure.
