### PR TITLE
Adjust GITHUB_TOKEN Permissions for Infra workflows

### DIFF
--- a/.github/workflows/ecr-shared-deploy-dev.yml
+++ b/.github/workflows/ecr-shared-deploy-dev.yml
@@ -20,6 +20,16 @@ on:
         required: false
         type: string
 
+# The least-privilege list for this GHA to work (the `id-token: write` is
+# necessary for the OIDC authentication) 
+permissions:
+  actions: read
+  contents: read
+  deployments: read
+  id-token: write
+  pull-requests: read
+  statuses: read
+
 # Set defaults
 defaults:
   run:
@@ -31,11 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     # This line adds a check for the user which is requesting the PR. As long as its not dependabot, we go ahead and run it. 
     if: ${{ github.triggering_actor != 'dependabot[bot]' }}
-    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
-    permissions:
-      id-token: write
-      contents: read
-
+    
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -84,7 +90,7 @@ jobs:
           architecture: x64
 
       - name: Get Ruby
-        # Run the Ruby setup setup only when there is a .ruby-version file in the 
+        # Run the Ruby setup only when there is a .ruby-version file in the 
         # root of the repository. Otherwise, this step is skipped.
         if: ${{ env.ruby_repo == 1 }}
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/ecr-shared-deploy-stage.yml
+++ b/.github/workflows/ecr-shared-deploy-stage.yml
@@ -20,6 +20,16 @@ on:
         required: false
         type: string
 
+# The least-privilege list for this GHA to work (the `id-token: write` is
+# necessary for the OIDC authentication) 
+permissions:
+  actions: read
+  contents: read
+  deployments: read
+  id-token: write
+  pull-requests: read
+  statuses: read
+
 # Set defaults
 defaults:
   run:
@@ -29,10 +39,6 @@ jobs:
   deploy:
     name: Build and Deploy to ECR
     runs-on: ubuntu-latest
-    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
-    permissions:
-      id-token: write
-      contents: read
 
     steps:
       - name: Checkout code

--- a/.github/workflows/ecr-shared-promote-prod.yml
+++ b/.github/workflows/ecr-shared-promote-prod.yml
@@ -23,7 +23,15 @@ on:
         required: false
         type: string
 
-permissions: read-all
+# The least-privilege list for this GHA to work (the `id-token: write` is
+# necessary for the OIDC authentication) 
+permissions:
+  actions: read
+  contents: read
+  deployments: read
+  id-token: write
+  pull-requests: read
+  statuses: read
 
 # Set defaults
 defaults:
@@ -36,10 +44,6 @@ jobs:
     name: Promote Build to Prod
     # Download from Stage then upload to Prod
     runs-on: ubuntu-latest
-    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
-    permissions:
-      id-token: write
-      contents: read
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tf-checkov-shared.yml
+++ b/.github/workflows/tf-checkov-shared.yml
@@ -8,6 +8,8 @@ name: Checkov
 on:
   workflow_call:
 
+permissions: read-all
+
 jobs:
   checkov:
     name: run checkov

--- a/.github/workflows/tf-docs-shared.yml
+++ b/.github/workflows/tf-docs-shared.yml
@@ -9,6 +9,8 @@ name: Check terraform-docs
 on:
   workflow_call:
 
+permissions: read-all
+
 jobs:
   docs:
     name: terraform-docs

--- a/.github/workflows/tf-validate-shared.yml
+++ b/.github/workflows/tf-validate-shared.yml
@@ -7,6 +7,8 @@ defaults:
   run:
     shell: bash
 
+permissions: read-all
+
 jobs:
   validate-terraform:
     name: terraform fmt & validate


### PR DESCRIPTION
### Why these changes are being introduced

A recent deployment problem with the docker-matomo repository highlighted the fact that we had some conflicting permissions in our shared and caller workflows for container deployments. In order to address that mismatch, there are some simple updates to the shared workflows here to set permissions for the GITHUB_TOKEN appropriately for these workflows. There will need to be some changes to some of the caller workflows to ensure that the caller/shared process works correctly with more restrictive permissions.

**Note**: No changes are made to the `tf-docs-gen-shared.yml` file because it is deprecated. As soon as references to it from the last three Terraform repos are removed, it will be deleted.

### How this addresses that need

* Update the `permissions:` to reflect on the necessary read and write permissions for the workflow
* Update the three tf- shared workflows to adjust the GITHUB_TOKEN permissions to "read-all"

### Side effects of this change

None

