### PR TITLE
New Workflows To Support ARM64 and AMD64 Container Deploys

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,33 @@
+# CODEOWNERS file (from GitHub template at
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners)
+# Each line is a file pattern followed by one or more owners.
+
+################################################################################
+# These owners will be the default owners for everything in the repo. Unless a
+# later match takes precedence, these users will be requested for review when 
+# someone opens a pull request. This is commented out in favor of the 
+# "Engineering Leads" team (see below).
+# * @cabutlermit @JPrevost
+
+# Teams can be specified as code owners as well. Teams should be identified in
+# the format @org/team-name. Teams must have explicit write access to the 
+# repository.
+* @mitlibraries/engineering-leads
+
+# We can set explicit users or teams for files with particular names or 
+# paths. We start by protecting the CODEOWNERS file by linking it to the two 
+# GitHub Organization owners:
+/.github/CODEOWNERS @mitlibraries/engineering-leads
+
+# The ECR, Terraform, CDN, and CloudFormation workflows are managed by InfraEng:
+/.github/workflows/ecr* @mitlibraries/infraeng
+/.github/workflows/tf* @mitlibraries/infraeng
+/.github/workflows/cdn* @mitlibraries/infraeng
+/.github/workflows/cf* @mitlibraries/infraeng
+
+# The Python publishing workflows are managed by DataEng:
+/.github/workflows/python* @mitlibraries/dataeng
+
+# The Ruby publishing workflows are managed by EngX/engx
+/.github/workflows/ruby* @mitlibraries/engx
+/workflow-templates.* @mitlibraries/engx

--- a/.github/workflows/ecr-multi-arch-deploy-dev.yml
+++ b/.github/workflows/ecr-multi-arch-deploy-dev.yml
@@ -35,7 +35,7 @@ permissions:
 
 jobs:
   deploy:
-    name: Build and Deploy to ECR
+    name: Build and Deploy to Dev1 ECR
     runs-on: ubuntu-latest
     # This line adds a check for the user which is requesting the PR. As long as its not dependabot, we go ahead and run it. 
     if: ${{ github.triggering_actor != 'dependabot[bot]' }}
@@ -57,12 +57,6 @@ jobs:
           if [[ -f ".ruby-version" ]]; then
             echo "ruby_repo=1" >> $GITHUB_OUTPUT
           fi
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v5
-        with:
-          aws-region: ${{ inputs.AWS_REGION }}
-          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCT_DEV }}:role/${{ inputs.GHA_ROLE }}
 
       - name: Create tags
         # Extra effort on tagging is necessary because GHA checkout uses a "detached head" 
@@ -98,32 +92,36 @@ jobs:
         if: ${{ inputs.PREBUILD != '' }} 
         run: ${{ inputs.PREBUILD }}
 
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v5
+        with:
+          aws-region: ${{ inputs.AWS_REGION }}
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCT_DEV }}:role/${{ inputs.GHA_ROLE }}
+
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
 
-      - name: Build container
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and Push container
+        uses: docker/build-push-action@v6
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           REPOSITORY: ${{ inputs.ECR }}
           TAG_SHA: ${{ steps.tags.outputs.tag_sha}}
           TAG_PR: ${{ steps.tags.outputs.tag_pr}}
-        run: |
-          docker buildx create --use
-          DOCKER_BUILDKIT=1 docker buildx build --platform ${{ inputs.CPU_ARCH }} \
-            -t $REGISTRY/$REPOSITORY:latest \
-            -t $REGISTRY/$REPOSITORY:$TAG_SHA \
-            -t $REGISTRY/$REPOSITORY:$TAG_PR .
-
-      - name: Push container
-        env:
-          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          TAG_SHA: ${{ steps.tags.outputs.tag_sha}}
-          TAG_PR: ${{ steps.tags.outputs.tag_pr}}
-        run: |
-          docker push $REGISTRY/$REPOSITORY:latest
-          docker push $REGISTRY/$REPOSITORY:$TAG_SHA
-          docker push $REGISTRY/$REPOSITORY:$TAG_PR
+        with: 
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          context: .
+          push: true
+          platforms: ${{ inputs.CPU_ARCH }}
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:latest
+            ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:${{ env.TAG_SHA }}
+            ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:${{ env.TAG_PR }}
 
       - name: Update Lambda Function
         env:
@@ -134,5 +132,5 @@ jobs:
         run: |
           aws lambda update-function-code \ 
             --function-name ${{ inputs.FUNCTION }} \
-            --image-uri $REGISTRY/$REPOSITORY:latest \
+            --image-uri ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:latest \
             --query "LastUpdateStatusReasonCode" --output text

--- a/.github/workflows/ecr-multi-arch-deploy-dev.yml
+++ b/.github/workflows/ecr-multi-arch-deploy-dev.yml
@@ -29,6 +29,7 @@ defaults:
   run:
     shell: bash
 
+# These permissions are needed to interact with GitHub's OIDC Token endpoint.
 permissions:
   id-token: write
   contents: read
@@ -36,10 +37,10 @@ permissions:
 jobs:
   deploy:
     name: Build and Deploy to Dev1 ECR on ${{ inputs.CPU_ARCH }}
-    runs-on: ${{ inputs.CPU_ARCH == 'linux/arm64' && 'ubuntu-22.04-arm' || 'ubuntu-latest'  }}
+    # Pick a runner that matches the CPU architecture of the container
+    runs-on: ${{ inputs.CPU_ARCH == 'linux/arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest'  }}
     # This line adds a check for the user which is requesting the PR. As long as its not dependabot, we go ahead and run it. 
     if: ${{ github.triggering_actor != 'dependabot[bot]' }}
-    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
 
     steps:
       - name: Checkout code

--- a/.github/workflows/ecr-multi-arch-deploy-dev.yml
+++ b/.github/workflows/ecr-multi-arch-deploy-dev.yml
@@ -82,7 +82,9 @@ jobs:
         # Run the Python setup only when there is a .python-version file in the root
         # of the repository. Otherwise, this step is skipped.
         if: ${{ steps.buildcheck.outputs.python_repo == '1' }}
-        uses: actions/setup-python@v5 # by default, this uses the .python-version file to set the version
+        uses: actions/setup-python@v5
+        with: 
+          python-version-file: '.python-version'
 
       - name: Get Ruby
         # Run the Ruby setup setup only when there is a .ruby-version file in the 
@@ -107,7 +109,8 @@ jobs:
           TAG_SHA: ${{ steps.tags.outputs.tag_sha}}
           TAG_PR: ${{ steps.tags.outputs.tag_pr}}
         run: |
-          DOCKER_BUILDKIT=1 docker build --platform ${{ inputs.CPU_ARCH }} \
+          docker buildx create --use
+          DOCKER_BUILDKIT=1 docker buildx build --platform ${{ inputs.CPU_ARCH }} \
             -t $REGISTRY/$REPOSITORY:latest \
             -t $REGISTRY/$REPOSITORY:$TAG_SHA \
             -t $REGISTRY/$REPOSITORY:$TAG_PR .

--- a/.github/workflows/ecr-multi-arch-deploy-dev.yml
+++ b/.github/workflows/ecr-multi-arch-deploy-dev.yml
@@ -36,7 +36,7 @@ permissions:
 
 jobs:
   deploy:
-    name: Build and Deploy to Dev1 ECR on ${{ inputs.CPU_ARCH }}
+    name: AWS ECR on ${{ inputs.CPU_ARCH }}
     # Pick a runner that matches the CPU architecture of the container
     runs-on: ${{ inputs.CPU_ARCH == 'linux/arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest'  }}
     # This line adds a check for the user which is requesting the PR. As long as its not dependabot, we go ahead and run it. 
@@ -109,34 +109,42 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
 
-      - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
       - name: Build and Push container
-        uses: docker/build-push-action@v6
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           REPOSITORY: ${{ inputs.ECR }}
           TAG_SHA: ${{ steps.tags.outputs.tag_sha }}
           TAG_PR: ${{ steps.tags.outputs.tag_pr }}
           TAG_LATEST: ${{ steps.tags.outputs.tag_latest }}
-        with:
-          context: .
-          push: true
-          platforms: ${{ inputs.CPU_ARCH }}
-          tags: |
-            ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:${{ env.TAG_LATEST }}
-            ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:${{ env.TAG_SHA }}
-            ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:${{ env.TAG_PR }}
+        run: |
+          echo "### :whale: Docker Build" >> $GITHUB_STEP_SUMMARY
+          DOCKER_BUILDKIT=1 docker build \
+            -t ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:${{ env.TAG_LATEST }} \
+            -t ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:${{ env.TAG_SHA }} \
+            -t ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:${{ env.TAG_PR }} \
+            .
+          docker push ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:${{ env.TAG_LATEST }}
+          docker push ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:${{ env.TAG_SHA }}
+          docker push ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:${{ env.TAG_PR }}
+          
+          echo "✅ Successfully built and deployed the container." >> $GITHUB_STEP_SUMMARY
+          echo "**Platform**: \`${{ inputs.CPU_ARCH }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Tags**:" >> $GITHUB_STEP_SUMMARY
+          echo "- \`${{ env.TAG_LATEST }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- \`${{ env.TAG_SHA }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- \`${{ env.TAG_PR }}\`" >> $GITHUB_STEP_SUMMARY
 
       - name: Update Lambda Function
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           REPOSITORY: ${{ inputs.ECR }}
+          TAG_LATEST: ${{ steps.tags.outputs.tag_latest }}
         # Only update the Lambda Function if the developer passes in the Lambda Function name
         if: ${{ inputs.FUNCTION != '' }}
         run: |
+          echo "### λ Lambda Update" >> $GITHUB_STEP_SUMMARY
           aws lambda update-function-code \ 
             --function-name ${{ inputs.FUNCTION }} \
-            --image-uri ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:latest \
+            --image-uri ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:${{ env.TAG_LATEST }} \
             --query "LastUpdateStatusReasonCode" --output text
+          echo "✅ The Lambda function definition for \`${{ inputs.FUNCTION }}\` has been updated in Dev." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ecr-multi-arch-deploy-dev.yml
+++ b/.github/workflows/ecr-multi-arch-deploy-dev.yml
@@ -35,8 +35,8 @@ permissions:
 
 jobs:
   deploy:
-    name: Build and Deploy to Dev1 ECR
-    runs-on: ubuntu-latest
+    name: Build and Deploy to Dev1 ECR on ${{ inputs.CPU_ARCH }}
+    runs-on: ${{ inputs.CPU_ARCH == 'linux/arm64' && 'ubuntu-22.04-arm' || 'ubuntu-latest'  }}
     # This line adds a check for the user which is requesting the PR. As long as its not dependabot, we go ahead and run it. 
     if: ${{ github.triggering_actor != 'dependabot[bot]' }}
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
@@ -112,9 +112,7 @@ jobs:
           REPOSITORY: ${{ inputs.ECR }}
           TAG_SHA: ${{ steps.tags.outputs.tag_sha}}
           TAG_PR: ${{ steps.tags.outputs.tag_pr}}
-        with: 
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+        with:
           context: .
           push: true
           platforms: ${{ inputs.CPU_ARCH }}

--- a/.github/workflows/ecr-multi-arch-deploy-dev.yml
+++ b/.github/workflows/ecr-multi-arch-deploy-dev.yml
@@ -63,12 +63,18 @@ jobs:
         # Extra effort on tagging is necessary because GHA checkout uses a "detached head" 
         id: tags
         run: |
+          CLEANED_ARCH=$(echo ${{ inputs.CPU_ARCH }} | cut -d'/' -f2)
           if [ $GITHUB_EVENT_NAME = "workflow_dispatch" ]; then
             TAG_SHA=$(echo $GITHUB_SHA | cut -c 1-8) && \
             TAG_PR=$GITHUB_EVENT_NAME
           else
             TAG_SHA=$(echo ${{ github.event.pull_request.head.sha }} | cut -c 1-8) && \
             TAG_PR=$(echo "PR-"${{ github.event.pull_request.number }})
+          fi
+          if [[ -f ".aws-architecture" ]]; then
+            echo "tag_latest=latest-${CLEANED_ARCH}" >> $GITHUB_OUTPUT
+          else
+            echo "tag_latest=latest" >> $GITHUB_OUTPUT
           fi
           echo "tag_sha=${TAG_SHA}" >> $GITHUB_OUTPUT
           echo "tag_pr=${TAG_PR}" >> $GITHUB_OUTPUT
@@ -111,14 +117,15 @@ jobs:
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           REPOSITORY: ${{ inputs.ECR }}
-          TAG_SHA: ${{ steps.tags.outputs.tag_sha}}
-          TAG_PR: ${{ steps.tags.outputs.tag_pr}}
+          TAG_SHA: ${{ steps.tags.outputs.tag_sha }}
+          TAG_PR: ${{ steps.tags.outputs.tag_pr }}
+          TAG_LATEST: ${{ steps.tags.outputs.tag_latest }}
         with:
           context: .
           push: true
           platforms: ${{ inputs.CPU_ARCH }}
           tags: |
-            ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:latest
+            ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:${{ env.TAG_LATEST }}
             ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:${{ env.TAG_SHA }}
             ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:${{ env.TAG_PR }}
 

--- a/.github/workflows/ecr-multi-arch-deploy-dev.yml
+++ b/.github/workflows/ecr-multi-arch-deploy-dev.yml
@@ -1,0 +1,135 @@
+# ECS Container Deployment for Fargate & Lambda for both ARM64 and AMD64
+name: Dev Deploy Container Multi-Arch
+
+on:
+  workflow_call:
+    inputs:
+      AWS_REGION:
+        default: 'us-east-1'
+        required: false
+        type: string
+      GHA_ROLE:
+        required: true
+        type: string
+      CPU_ARCH: # either linux/arm64 or linux/amd64
+        required: true
+        type: string
+      ECR:
+        required: true
+        type: string
+      FUNCTION:
+        required: false
+        type: string
+      PREBUILD:
+        required: false
+        type: string
+
+# Set defaults
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  deploy:
+    name: Build and Deploy to ECR
+    runs-on: ubuntu-latest
+    # This line adds a check for the user which is requesting the PR. As long as its not dependabot, we go ahead and run it. 
+    if: ${{ github.triggering_actor != 'dependabot[bot]' }}
+    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Check Python or Ruby
+        id: buildcheck
+        # Check for the existence of files that set either the Python version or the Ruby version
+        # and capture this information for later use in the job. These values are used for
+        # conditional steps below to setup/configure the build environment for the container.
+        run: |
+          if [[ -f ".python-version" ]]; then
+            echo "python_repo=1" >> $GITHUB_OUTPUT
+          fi
+          if [[ -f ".ruby-version" ]]; then
+            echo "ruby_repo=1" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v5
+        with:
+          aws-region: ${{ inputs.AWS_REGION }}
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCT_DEV }}:role/${{ inputs.GHA_ROLE }}
+
+      - name: Create tags
+        # Extra effort on tagging is necessary because GHA checkout uses a "detached head" 
+        id: tags
+        run: |
+          if [ $GITHUB_EVENT_NAME = "workflow_dispatch" ]; then
+            TAG_SHA=$(echo $GITHUB_SHA | cut -c 1-8) && \
+            TAG_PR=$GITHUB_EVENT_NAME
+          else
+            TAG_SHA=$(echo ${{ github.event.pull_request.head.sha }} | cut -c 1-8) && \
+            TAG_PR=$(echo "PR-"${{ github.event.pull_request.number }})
+          fi
+          echo "tag_sha=${TAG_SHA}" >> $GITHUB_OUTPUT
+          echo "tag_pr=${TAG_PR}" >> $GITHUB_OUTPUT
+
+      - name: Get Python
+        # Run the Python setup only when there is a .python-version file in the root
+        # of the repository. Otherwise, this step is skipped.
+        if: ${{ steps.buildcheck.outputs.python_repo == '1' }}
+        uses: actions/setup-python@v5 # by default, this uses the .python-version file to set the version
+
+      - name: Get Ruby
+        # Run the Ruby setup setup only when there is a .ruby-version file in the 
+        # root of the repository. Otherwise, this step is skipped.
+        if: ${{ steps.buildcheck.outputs.ruby_repo == '1' }}
+        uses: ruby/setup-ruby@v1 # by default, this uses the .ruby-version file to set the version
+
+      - name: Run pre-build steps
+        # Only run this step if the app developer has specified "pre-build" commands
+        # in the caller workflow.
+        if: ${{ inputs.PREBUILD != '' }} 
+        run: ${{ inputs.PREBUILD }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build container
+        env:
+          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          REPOSITORY: ${{ inputs.ECR }}
+          TAG_SHA: ${{ steps.tags.outputs.tag_sha}}
+          TAG_PR: ${{ steps.tags.outputs.tag_pr}}
+        run: |
+          DOCKER_BUILDKIT=1 docker build --platform ${{ inputs.CPU_ARCH }} \
+            -t $REGISTRY/$REPOSITORY:latest \
+            -t $REGISTRY/$REPOSITORY:$TAG_SHA \
+            -t $REGISTRY/$REPOSITORY:$TAG_PR .
+
+      - name: Push container
+        env:
+          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          TAG_SHA: ${{ steps.tags.outputs.tag_sha}}
+          TAG_PR: ${{ steps.tags.outputs.tag_pr}}
+        run: |
+          docker push $REGISTRY/$REPOSITORY:latest
+          docker push $REGISTRY/$REPOSITORY:$TAG_SHA
+          docker push $REGISTRY/$REPOSITORY:$TAG_PR
+
+      - name: Update Lambda Function
+        env:
+          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          REPOSITORY: ${{ inputs.ECR }}
+        # Only update the Lambda Function if the developer passes in the Lambda Function name
+        if: ${{ inputs.FUNCTION != '' }}
+        run: |
+          aws lambda update-function-code \ 
+            --function-name ${{ inputs.FUNCTION }} \
+            --image-uri $REGISTRY/$REPOSITORY:latest \
+            --query "LastUpdateStatusReasonCode" --output text

--- a/.github/workflows/ecr-multi-arch-deploy-stage.yml
+++ b/.github/workflows/ecr-multi-arch-deploy-stage.yml
@@ -36,7 +36,7 @@ permissions:
 
 jobs:
   deploy:
-    name: Build and Deploy to Stage ECR on ${{ inputs.CPU_ARCH }}
+    name: AWS ECR on ${{ inputs.CPU_ARCH }}
     # Pick a runner that matches the CPU architecture of the container
     runs-on: ${{ inputs.CPU_ARCH == 'linux/arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest'  }}
     # This line adds a check for the user which is requesting the PR. As long as its not dependabot, we go ahead and run it. 
@@ -63,8 +63,14 @@ jobs:
         # Extra effort on tagging is necessary because GHA checkout uses a "detached head" 
         id: tags
         run: |
+          CLEANED_ARCH=$(echo ${{ inputs.CPU_ARCH }} | cut -d'/' -f2)
           TAG_SHA=$(echo $GITHUB_SHA | cut -c 1-8)
           echo "tag_sha=${TAG_SHA}" >> $GITHUB_OUTPUT
+          if [[ -f ".aws-architecture" ]]; then
+            echo "tag_latest=latest-${CLEANED_ARCH}" >> $GITHUB_OUTPUT
+          else
+            echo "tag_latest=latest" >> $GITHUB_OUTPUT
+          fi
 
       - name: Get Python
         # Run the Python setup only when there is a .python-version file in the root
@@ -96,31 +102,38 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
 
-      - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
       - name: Build and Push container
-        uses: docker/build-push-action@v6
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           REPOSITORY: ${{ inputs.ECR }}
           TAG_SHA: ${{ steps.tags.outputs.tag_sha }}
-        with:
-          context: .
-          push: true
-          platforms: ${{ inputs.CPU_ARCH }}
-          tags: |
-            ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:latest
-            ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:${{ env.TAG_SHA }}
+          TAG_LATEST: ${{ steps.tags.outputs.tag_latest }}
+        run: |
+          echo "### :whale: Docker Build" >> $GITHUB_STEP_SUMMARY
+          DOCKER_BUILDKIT=1 docker build \
+            -t ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:${{ env.TAG_LATEST }} \
+            -t ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:${{ env.TAG_SHA }} \
+            .
+          docker push ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:${{ env.TAG_LATEST }}
+          docker push ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:${{ env.TAG_SHA }}
+          
+          echo "✅ Successfully built and deployed the container." >> $GITHUB_STEP_SUMMARY
+          echo "**Platform**: \`${{ inputs.CPU_ARCH }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Tags**:" >> $GITHUB_STEP_SUMMARY
+          echo "- \`${{ env.TAG_LATEST }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- \`${{ env.TAG_SHA }}\`" >> $GITHUB_STEP_SUMMARY
 
       - name: Update Lambda Function
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           REPOSITORY: ${{ inputs.ECR }}
+          TAG_LATEST: ${{ steps.tags.outputs.tag_latest }}
         # Only update the Lambda Function if the developer passes in the Lambda Function name
         if: ${{ inputs.FUNCTION != '' }}
         run: |
+          echo "### λ Lambda Update" >> $GITHUB_STEP_SUMMARY
           aws lambda update-function-code \ 
             --function-name ${{ inputs.FUNCTION }} \
-            --image-uri ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:latest \
+            --image-uri ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:${{ env.TAG_LATEST }} \
             --query "LastUpdateStatusReasonCode" --output text
+          echo "✅ The Lambda function definition for \`${{ inputs.FUNCTION }}\` has been updated in Stage." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ecr-multi-arch-deploy-stage.yml
+++ b/.github/workflows/ecr-multi-arch-deploy-stage.yml
@@ -29,17 +29,18 @@ defaults:
   run:
     shell: bash
 
+# These permissions are needed to interact with GitHub's OIDC Token endpoint.
 permissions:
   id-token: write
   contents: read
 
 jobs:
   deploy:
-    name: Build and Deploy to ECR
-    runs-on: ubuntu-latest
+    name: Build and Deploy to Stage ECR on ${{ inputs.CPU_ARCH }}
+    # Pick a runner that matches the CPU architecture of the container
+    runs-on: ${{ inputs.CPU_ARCH == 'linux/arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest'  }}
     # This line adds a check for the user which is requesting the PR. As long as its not dependabot, we go ahead and run it. 
     if: ${{ github.triggering_actor != 'dependabot[bot]' }}
-    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
 
     steps:
       - name: Checkout code
@@ -58,31 +59,20 @@ jobs:
             echo "ruby_repo=1" >> $GITHUB_OUTPUT
           fi
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v5
-        with:
-          aws-region: ${{ inputs.AWS_REGION }}
-          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCT_STAGE }}:role/${{ inputs.GHA_ROLE }}
-
       - name: Create tags
         # Extra effort on tagging is necessary because GHA checkout uses a "detached head" 
         id: tags
         run: |
-          if [ $GITHUB_EVENT_NAME = "workflow_dispatch" ]; then
-            TAG_SHA=$(echo $GITHUB_SHA | cut -c 1-8) && \
-            TAG_PR=$GITHUB_EVENT_NAME
-          else
-            TAG_SHA=$(echo ${{ github.event.pull_request.head.sha }} | cut -c 1-8) && \
-            TAG_PR=$(echo "PR-"${{ github.event.pull_request.number }})
-          fi
+          TAG_SHA=$(echo $GITHUB_SHA | cut -c 1-8)
           echo "tag_sha=${TAG_SHA}" >> $GITHUB_OUTPUT
-          echo "tag_pr=${TAG_PR}" >> $GITHUB_OUTPUT
 
       - name: Get Python
         # Run the Python setup only when there is a .python-version file in the root
         # of the repository. Otherwise, this step is skipped.
         if: ${{ steps.buildcheck.outputs.python_repo == '1' }}
-        uses: actions/setup-python@v5 # by default, this uses the .python-version file to set the version
+        uses: actions/setup-python@v5
+        with: 
+          python-version-file: '.python-version'
 
       - name: Get Ruby
         # Run the Ruby setup setup only when there is a .ruby-version file in the 
@@ -96,31 +86,32 @@ jobs:
         if: ${{ inputs.PREBUILD != '' }} 
         run: ${{ inputs.PREBUILD }}
 
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v5
+        with:
+          aws-region: ${{ inputs.AWS_REGION }}
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCT_STAGE }}:role/${{ inputs.GHA_ROLE }}
+
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
 
-      - name: Build container
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and Push container
+        uses: docker/build-push-action@v6
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           REPOSITORY: ${{ inputs.ECR }}
-          TAG_SHA: ${{ steps.tags.outputs.tag_sha}}
-          TAG_PR: ${{ steps.tags.outputs.tag_pr}}
-        run: |
-          DOCKER_BUILDKIT=1 docker build --platform ${{ inputs.CPU_ARCH }} \
-            -t $REGISTRY/$REPOSITORY:latest \
-            -t $REGISTRY/$REPOSITORY:$TAG_SHA \
-            -t $REGISTRY/$REPOSITORY:$TAG_PR .
-
-      - name: Push container
-        env:
-          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          TAG_SHA: ${{ steps.tags.outputs.tag_sha}}
-          TAG_PR: ${{ steps.tags.outputs.tag_pr}}
-        run: |
-          docker push $REGISTRY/$REPOSITORY:latest
-          docker push $REGISTRY/$REPOSITORY:$TAG_SHA
-          docker push $REGISTRY/$REPOSITORY:$TAG_PR
+          TAG_SHA: ${{ steps.tags.outputs.tag_sha }}
+        with:
+          context: .
+          push: true
+          platforms: ${{ inputs.CPU_ARCH }}
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:latest
+            ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:${{ env.TAG_SHA }}
 
       - name: Update Lambda Function
         env:
@@ -131,5 +122,5 @@ jobs:
         run: |
           aws lambda update-function-code \ 
             --function-name ${{ inputs.FUNCTION }} \
-            --image-uri $REGISTRY/$REPOSITORY:latest \
+            --image-uri ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:latest \
             --query "LastUpdateStatusReasonCode" --output text

--- a/.github/workflows/ecr-multi-arch-deploy-stage.yml
+++ b/.github/workflows/ecr-multi-arch-deploy-stage.yml
@@ -1,0 +1,135 @@
+# ECS Container Deployment for Fargate & Lambda for both ARM64 and AMD64
+name: Stage Deploy Container Multi-Arch
+
+on:
+  workflow_call:
+    inputs:
+      AWS_REGION:
+        default: 'us-east-1'
+        required: false
+        type: string
+      GHA_ROLE:
+        required: true
+        type: string
+      CPU_ARCH: # either linux/arm64 or linux/amd64
+        required: true
+        type: string
+      ECR:
+        required: true
+        type: string
+      FUNCTION:
+        required: false
+        type: string
+      PREBUILD:
+        required: false
+        type: string
+
+# Set defaults
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  deploy:
+    name: Build and Deploy to ECR
+    runs-on: ubuntu-latest
+    # This line adds a check for the user which is requesting the PR. As long as its not dependabot, we go ahead and run it. 
+    if: ${{ github.triggering_actor != 'dependabot[bot]' }}
+    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Check Python or Ruby
+        id: buildcheck
+        # Check for the existence of files that set either the Python version or the Ruby version
+        # and capture this information for later use in the job. These values are used for
+        # conditional steps below to setup/configure the build environment for the container.
+        run: |
+          if [[ -f ".python-version" ]]; then
+            echo "python_repo=1" >> $GITHUB_OUTPUT
+          fi
+          if [[ -f ".ruby-version" ]]; then
+            echo "ruby_repo=1" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v5
+        with:
+          aws-region: ${{ inputs.AWS_REGION }}
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCT_STAGE }}:role/${{ inputs.GHA_ROLE }}
+
+      - name: Create tags
+        # Extra effort on tagging is necessary because GHA checkout uses a "detached head" 
+        id: tags
+        run: |
+          if [ $GITHUB_EVENT_NAME = "workflow_dispatch" ]; then
+            TAG_SHA=$(echo $GITHUB_SHA | cut -c 1-8) && \
+            TAG_PR=$GITHUB_EVENT_NAME
+          else
+            TAG_SHA=$(echo ${{ github.event.pull_request.head.sha }} | cut -c 1-8) && \
+            TAG_PR=$(echo "PR-"${{ github.event.pull_request.number }})
+          fi
+          echo "tag_sha=${TAG_SHA}" >> $GITHUB_OUTPUT
+          echo "tag_pr=${TAG_PR}" >> $GITHUB_OUTPUT
+
+      - name: Get Python
+        # Run the Python setup only when there is a .python-version file in the root
+        # of the repository. Otherwise, this step is skipped.
+        if: ${{ steps.buildcheck.outputs.python_repo == '1' }}
+        uses: actions/setup-python@v5 # by default, this uses the .python-version file to set the version
+
+      - name: Get Ruby
+        # Run the Ruby setup setup only when there is a .ruby-version file in the 
+        # root of the repository. Otherwise, this step is skipped.
+        if: ${{ steps.buildcheck.outputs.ruby_repo == '1' }}
+        uses: ruby/setup-ruby@v1 # by default, this uses the .ruby-version file to set the version
+
+      - name: Run pre-build steps
+        # Only run this step if the app developer has specified "pre-build" commands
+        # in the caller workflow.
+        if: ${{ inputs.PREBUILD != '' }} 
+        run: ${{ inputs.PREBUILD }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build container
+        env:
+          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          REPOSITORY: ${{ inputs.ECR }}
+          TAG_SHA: ${{ steps.tags.outputs.tag_sha}}
+          TAG_PR: ${{ steps.tags.outputs.tag_pr}}
+        run: |
+          DOCKER_BUILDKIT=1 docker build --platform ${{ inputs.CPU_ARCH }} \
+            -t $REGISTRY/$REPOSITORY:latest \
+            -t $REGISTRY/$REPOSITORY:$TAG_SHA \
+            -t $REGISTRY/$REPOSITORY:$TAG_PR .
+
+      - name: Push container
+        env:
+          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          TAG_SHA: ${{ steps.tags.outputs.tag_sha}}
+          TAG_PR: ${{ steps.tags.outputs.tag_pr}}
+        run: |
+          docker push $REGISTRY/$REPOSITORY:latest
+          docker push $REGISTRY/$REPOSITORY:$TAG_SHA
+          docker push $REGISTRY/$REPOSITORY:$TAG_PR
+
+      - name: Update Lambda Function
+        env:
+          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          REPOSITORY: ${{ inputs.ECR }}
+        # Only update the Lambda Function if the developer passes in the Lambda Function name
+        if: ${{ inputs.FUNCTION != '' }}
+        run: |
+          aws lambda update-function-code \ 
+            --function-name ${{ inputs.FUNCTION }} \
+            --image-uri $REGISTRY/$REPOSITORY:latest \
+            --query "LastUpdateStatusReasonCode" --output text

--- a/.github/workflows/ecr-multi-arch-promote-prod.yml
+++ b/.github/workflows/ecr-multi-arch-promote-prod.yml
@@ -20,6 +20,9 @@ on:
       ECR_PROD:
         required: true
         type: string
+      CPU_ARCH: # either linux/arm64 or linux/amd64
+        required: true
+        type: string
       FUNCTION:
         required: false
         type: string
@@ -35,13 +38,16 @@ defaults:
     shell: bash
 
 jobs:
-  deploy:
+  promote:
     if: ${{ github.ref == 'refs/heads/main' || github.event.release.target_commitish == 'main' }}
-    name: Promote Build to Prod
+    name: Promote to Prod
     # E.g., download from Stage then upload to Prod
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
       - name: Configure AWS credentials for Stage
         id: login-aws-stage
         uses: aws-actions/configure-aws-credentials@v5
@@ -49,30 +55,42 @@ jobs:
           aws-region: ${{ inputs.AWS_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCT_STAGE }}:role/${{ inputs.GHA_ROLE_STAGE }}
 
+      - name: Set Architecture
+        id: cpu_arch
+        run: |
+          CLEANED_ARCH=$(echo ${{ inputs.CPU_ARCH }} | cut -d'/' -f2)
+          if [[ -f ".aws-architecture" ]]; then
+            echo "tag_latest=latest-${CLEANED_ARCH}" >> $GITHUB_OUTPUT
+          else
+            echo "tag_latest=latest" >> $GITHUB_OUTPUT
+          fi
+
       - name: Check SHAs
         # A fail-safe check to verify that the SHAs match between the `main` branch and
         # the ECR currently in Stage-Workloads
         id: check_sha
         env:
-            REPOSITORY: ${{ inputs.ECR_STAGE }}
+          REPOSITORY: ${{ inputs.ECR_STAGE }}
+          TAG_LATEST: ${{ steps.cpu_arch.outputs.tag_latest }}
         run: |
-          export ECR_SHA=$(aws ecr describe-images --repository-name $REPOSITORY --image-ids imageTag=latest --query 'imageDetails[].imageTags' | sed -E 's/[^a-zA-Z0-9]/\n/g' | grep -E '^[a-f0-9]{8}$')
+          export ECR_SHA=$(aws ecr describe-images --repository-name $REPOSITORY --image-ids imageTag=${{ env.TAG_LATEST }} --query 'imageDetails[].imageTags' | sed -E 's/[^a-zA-Z0-9]/\n/g' | grep -E '^[a-f0-9]{8}$')
           if [[ ${GITHUB_SHA::8} == $ECR_SHA ]]; then
             echo "sha_match=true" >> $GITHUB_OUTPUT
-            echo "#### SHA Match Success" >> $GITHUB_STEP_SUMMARY
+            echo "### SHA Match Success" >> $GITHUB_STEP_SUMMARY
+            echo "Continue to promoting the Stage container to Production." >> $GITHUB_STEP_SUMMARY
           else
             echo "sha_match=false" >> $GITHUB_OUTPUT
-            echo "#### SHA Match Failure" >> $GITHUB_STEP_SUMMARY
+            echo "### SHA Match Failure" >> $GITHUB_STEP_SUMMARY
             echo "FAILURE: Stage-Workloads SHA did not match the main branch." >> $GITHUB_STEP_SUMMARY
             exit 1
           fi
 
       - name: Create tags
-        # Capture the SHA and Release tags
+        # Capture the short SHA and Release tags
         if: ${{ steps.check_sha.outputs.sha_match == 'true' }}
         id: tags
         run: |
-          echo "tag_sha=$GITHUB_SHA" >> $GITHUB_OUTPUT
+          echo "tag_sha=${GITHUB_SHA::8}" >> $GITHUB_OUTPUT
           echo "tag_release=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
 
       - name: Login to Stage Amazon ECR
@@ -84,9 +102,11 @@ jobs:
         env:
           REGISTRY: ${{ steps.login-ecr-stage.outputs.registry }}
           REPOSITORY: ${{ inputs.ECR_STAGE }}
-        run: docker pull ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:${GITHUB_SHA::8}
+          TAG_SHA: ${{ steps.tags.outputs.tag_sha }}
+        run: docker pull ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:${{ env.TAG_SHA }}
 
       - name: Configure AWS credentials for Prod
+        if: ${{ steps.check_sha.outputs.sha_match == 'true' }}
         id: login-aws-prod
         uses: aws-actions/configure-aws-credentials@v5
         with:
@@ -94,6 +114,7 @@ jobs:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCT_PROD }}:role/${{ inputs.GHA_ROLE_PROD }}
 
       - name: Login to Prod Amazon ECR
+        if: ${{ steps.check_sha.outputs.sha_match == 'true' }}
         id: login-ecr-prod
         uses: aws-actions/amazon-ecr-login@v2
 
@@ -106,25 +127,26 @@ jobs:
           REPOSITORY_PROD: ${{ inputs.ECR_PROD }}
           TAG_SHA: ${{ steps.tags.outputs.tag_sha }}
           TAG_RELEASE: ${{ steps.tags.outputs.tag_release }}
+          TAG_LATEST: ${{ steps.cpu_arch.outputs.tag_latest }}
         run: |
-          docker tag ${{ env.REGISTRY_STAGE }}/${{ env.REPOSITORY_STAGE }}:${GITHUB_SHA::8} ${{ env.REGISTRY_PROD }}/${{ env.REPOSITORY_PROD }}:latest
-          docker tag ${{ env.REGISTRY_STAGE }}/${{ env.REPOSITORY_STAGE }}:${GITHUB_SHA::8} ${{ env.REGISTRY_PROD }}/${{ env.REPOSITORY_PROD }}:$TAG_SHA
+          echo "### :whale: Promote Container to Production" >> $GITHUB_STEP_SUMMARY
+          docker tag ${{ env.REGISTRY_STAGE }}/${{ env.REPOSITORY_STAGE }}:${{ env.TAG_SHA }} ${{ env.REGISTRY_PROD }}/${{ env.REPOSITORY_PROD }}:${{ env.TAG_LATEST }}
+          docker tag ${{ env.REGISTRY_STAGE }}/${{ env.REPOSITORY_STAGE }}:${{ env.TAG_SHA }} ${{ env.REGISTRY_PROD }}/${{ env.REPOSITORY_PROD }}:${{ env.TAG_SHA }}
+          docker push ${{ env.REGISTRY_PROD }}/${{ env.REPOSITORY_PROD }}:${{ env.TAG_LATEST }}
+          docker push ${{ env.REGISTRY_PROD }}/${{ env.REPOSITORY_PROD }}:${{ env.TAG_SHA }}
+          
+          echo "✅ Promoted image to Prod ECR with the following tags:" >> $GITHUB_STEP_SUMMARY
+          echo "- \`${{ env.TAG_LATEST }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- \`${{ env.TAG_SHA }}\` (GitHub SHA)" >> $GITHUB_STEP_SUMMARY
+
           if [ $GITHUB_EVENT_NAME != "workflow_dispatch" ]; then
-            docker tag ${{ env.REGISTRY_STAGE }}/${{ env.REPOSITORY_STAGE }}:${GITHUB_SHA::8} ${{ env.REGISTRY_PROD }}/${{ env.REPOSITORY_PROD }}:$TAG_RELEASE
-          fi
-            docker push ${{ env.REGISTRY_PROD }}/${{ env.REPOSITORY_PROD }}:latest
-          docker push ${{ env.REGISTRY_PROD }}/${{ env.REPOSITORY_PROD }}:$TAG_SHA
-          if [ $GITHUB_EVENT_NAME != "workflow_dispatch" ]; then
-            docker push ${{ env.REGISTRY_PROD }}/${{ env.REPOSITORY_PROD }}:$TAG_RELEASE
-          fi
-          echo "#### Promote Container to Production" >> $GITHUB_STEP_SUMMARY
-          echo "✅ Promoted image to Prod ECR:" >> $GITHUB_STEP_SUMMARY
-          echo "- latest" >> $GITHUB_STEP_SUMMARY
-          echo "- $TAG_SHA" >> $GITHUB_STEP_SUMMARY
-          if [ $GITHUB_EVENT_NAME != "workflow_dispatch" ]; then
-            echo "- $TAG_RELEASE" >> $GITHUB_STEP_SUMMARY
+            docker tag ${{ env.REGISTRY_STAGE }}/${{ env.REPOSITORY_STAGE }}:${GITHUB_SHA::8} ${{ env.REGISTRY_PROD }}/${{ env.REPOSITORY_PROD }}:${{ env.TAG_RELEASE }}
+            docker push ${{ env.REGISTRY_PROD }}/${{ env.REPOSITORY_PROD }}:${{ env.TAG_RELEASE }}
+            echo "- \`${{ env.TAG_RELEASE }}\` (GitHub Release Version)" >> $GITHUB_STEP_SUMMARY
           else
-            echo "- MANUAL RUN" >> $GITHUB_STEP_SUMMARY
+            docker tag ${{ env.REGISTRY_STAGE }}/${{ env.REPOSITORY_STAGE }}:${GITHUB_SHA::8} ${{ env.REGISTRY_PROD }}/${{ env.REPOSITORY_PROD }}:MANUAL_TRIGGER
+            docker push ${{ env.REGISTRY_PROD }}/${{ env.REPOSITORY_PROD }}:MANUAL_TRIGGER
+            echo "- \`MANUAL_TRIGGER\`" >> $GITHUB_STEP_SUMMARY
           fi
 
       - name: Update Lambda Function in Prod
@@ -133,11 +155,12 @@ jobs:
         env:
           REGISTRY_PROD: ${{ steps.login-ecr-prod.outputs.registry }}
           REPOSITORY_PROD: ${{ inputs.ECR_PROD }}
+          TAG_LATEST: ${{ steps.cpu_arch.outputs.tag_latest }}
         run: | 
           aws lambda update-function-code \
             --function-name ${{ inputs.FUNCTION }} \
-            --image-uri ${{ env.REGISTRY_PROD }}/${{ env.REPOSITORY_PROD }}:latest \
+            --image-uri ${{ env.REGISTRY_PROD }}/${{ env.REPOSITORY_PROD }}:${{ env.TAG_LATEST }} \
             --query "LastUpdateStatusReasonCode" \
             --output text
-          echo "#### Lambda Function" >> $GITHUB_STEP_SUMMARY
+          echo "### λ Lambda Function" >> $GITHUB_STEP_SUMMARY
           echo "✅ Lambda Function Updated" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ecr-multi-arch-promote-prod.yml
+++ b/.github/workflows/ecr-multi-arch-promote-prod.yml
@@ -1,0 +1,125 @@
+# ECS Container Deployment for Fargate & Lambda for both ARM64 and AMD64
+name: Prod Promote Container Multi-Arch
+
+on:
+  workflow_call:
+    inputs:
+      AWS_REGION:
+        default: 'us-east-1'
+        required: false
+        type: string
+      GHA_ROLE_STAGE:
+        required: true
+        type: string
+      GHA_ROLE_PROD:
+        required: true
+        type: string
+      ECR_STAGE:
+        required: true
+        type: string
+      ECR_PROD:
+        required: true
+        type: string
+      FUNCTION:
+        required: false
+        type: string
+
+permissions:
+  id-token: write
+  contents: read
+
+# Set defaults
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  deploy:
+    if: ${{ github.ref == 'refs/heads/main' || github.event.release.target_commitish == 'main' }}
+    name: Promote Build to Prod
+    # Download from Stage then upload to Prod
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Configure AWS credentials for Stage
+        id: login-aws-stage
+        uses: aws-actions/configure-aws-credentials@v5
+        with:
+          aws-region: ${{ inputs.AWS_REGION }}
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCT_STAGE }}:role/${{ inputs.GHA_ROLE_STAGE }}
+
+      - name: Check SHAs
+        # A fail-safe check to verify that the SHAs match between the `main` branch and
+        # the ECR currently in Stage-Workloads
+        id: check_sha
+        env:
+            REPOSITORY: ${{ inputs.ECR_STAGE }}
+        run: |
+          export HEAD_SHA=$(git rev-parse --short=8 HEAD)
+          export ECR_SHA=$(aws ecr describe-images --repository-name $REPOSITORY --image-ids imageTag=latest --query 'imageDetails[].imageTags' | sed -E 's/[^a-zA-Z0-9]/\n/g' | grep -E '^[a-f0-9]{8}$')
+          if [[ $HEAD_SHA == $ECR_SHA ]]; then
+            echo "sha_match=true" >> $GITHUB_OUTPUT
+          else
+            echo "sha_match=false" >> $GITHUB_OUTPUT
+            echo "FAILURE: Stage-Workloads SHA did not match the main branch." >> $GITHUB_STEP_SUMMARY
+            exit 1
+          fi
+
+      - name: Create tags
+        # Capture the SHA and Release tags
+        if: ${{ steps.check_sha.outputs.sha_match == 'true' }}
+        id: tags
+        run: |
+          echo "tag_sha=$GITHUB_SHA" >> $GITHUB_OUTPUT
+          echo "tag_release=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
+
+      - name: Login to Stage Amazon ECR
+        id: login-ecr-stage
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Download from Stage and re-tag
+        if: ${{ steps.check_sha.outputs.sha_match == 'true' }}
+        env:
+          REGISTRY: ${{ steps.login-ecr-stage.outputs.registry }}
+          REPOSITORY: ${{ inputs.ECR_STAGE }}
+        run: docker pull $REGISTRY/$REPOSITORY:latest
+
+      - name: Configure AWS credentials for Prod
+        id: login-aws-prod
+        uses: aws-actions/configure-aws-credentials@v5
+        with:
+          aws-region: ${{ inputs.AWS_REGION }}
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCT_PROD }}:role/${{ inputs.GHA_ROLE_PROD }}
+
+      - name: Login to Prod Amazon ECR
+        id: login-ecr-prod
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Re-tag and Push to PRod
+        if: ${{ steps.check_sha.outputs.sha_match == 'true' }}
+        env:
+          REGISTRY_STAGE: ${{ steps.login-ecr-stage.outputs.registry }}
+          REGISTRY_PROD: ${{ steps.login-ecr-prod.outputs.registry }}
+          REPOSITORY: ${{ inputs.ECR_PROD }}
+          TAG_SHA: ${{ steps.tags.outputs.tag_sha }}
+          TAG_RELEASE: ${{ steps.tags.outputs.tag_release }}
+        run: |
+          docker tag $REGISTRY_STAGE/$REPOSITORY:latest $REGISTRY_PROD/$REPOSITORY:latest
+          docker tag $REGISTRY_STAGE/$REPOSITORY:latest $REGISTRY_PROD/$REPOSITORY:$TAG_SHA
+          docker tag $REGISTRY_STAGE/$REPOSITORY:latest $REGISTRY_PROD/$REPOSITORY:$TAG_RELEASE
+          docker push $REGISTRY_PROD/$REPOSITORY:latest
+          docker push $REGISTRY_PROD/$REPOSITORY:$TAG_SHA
+          docker push $REGISTRY_PROD/$REPOSITORY:$TAG_RELEASE
+
+      - name: Update Lambda Function in Prod
+        # Only update the Lambda Function if the container is destined for Lambda
+        if: ${{ inputs.FUNCTION != '' && steps.check_sha.outputs.sha_match == 'true' }}
+        run: | 
+          aws lambda update-function-code \
+            --function-name ${{ inputs.FUNCTION }} \
+            --image-uri $REGISTRY_PROD/$REPOSITORY:latest \
+            --query "LastUpdateStatusReasonCode" \
+            --output text

--- a/.github/workflows/ecr-multi-arch-promote-prod.yml
+++ b/.github/workflows/ecr-multi-arch-promote-prod.yml
@@ -24,6 +24,7 @@ on:
         required: false
         type: string
 
+# These permissions are needed to interact with GitHub's OIDC Token endpoint.
 permissions:
   id-token: write
   contents: read
@@ -37,13 +38,10 @@ jobs:
   deploy:
     if: ${{ github.ref == 'refs/heads/main' || github.event.release.target_commitish == 'main' }}
     name: Promote Build to Prod
-    # Download from Stage then upload to Prod
+    # E.g., download from Stage then upload to Prod
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v5
-
       - name: Configure AWS credentials for Stage
         id: login-aws-stage
         uses: aws-actions/configure-aws-credentials@v5
@@ -58,12 +56,13 @@ jobs:
         env:
             REPOSITORY: ${{ inputs.ECR_STAGE }}
         run: |
-          export HEAD_SHA=$(git rev-parse --short=8 HEAD)
           export ECR_SHA=$(aws ecr describe-images --repository-name $REPOSITORY --image-ids imageTag=latest --query 'imageDetails[].imageTags' | sed -E 's/[^a-zA-Z0-9]/\n/g' | grep -E '^[a-f0-9]{8}$')
-          if [[ $HEAD_SHA == $ECR_SHA ]]; then
+          if [[ ${GITHUB_SHA::8} == $ECR_SHA ]]; then
             echo "sha_match=true" >> $GITHUB_OUTPUT
+            echo "#### SHA Match Success" >> $GITHUB_STEP_SUMMARY
           else
             echo "sha_match=false" >> $GITHUB_OUTPUT
+            echo "#### SHA Match Failure" >> $GITHUB_STEP_SUMMARY
             echo "FAILURE: Stage-Workloads SHA did not match the main branch." >> $GITHUB_STEP_SUMMARY
             exit 1
           fi
@@ -80,12 +79,12 @@ jobs:
         id: login-ecr-stage
         uses: aws-actions/amazon-ecr-login@v2
 
-      - name: Download from Stage and re-tag
+      - name: Download from Stage
         if: ${{ steps.check_sha.outputs.sha_match == 'true' }}
         env:
           REGISTRY: ${{ steps.login-ecr-stage.outputs.registry }}
           REPOSITORY: ${{ inputs.ECR_STAGE }}
-        run: docker pull $REGISTRY/$REPOSITORY:latest
+        run: docker pull ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:${GITHUB_SHA::8}
 
       - name: Configure AWS credentials for Prod
         id: login-aws-prod
@@ -98,28 +97,47 @@ jobs:
         id: login-ecr-prod
         uses: aws-actions/amazon-ecr-login@v2
 
-      - name: Re-tag and Push to PRod
+      - name: Re-tag and Push to Prod
         if: ${{ steps.check_sha.outputs.sha_match == 'true' }}
         env:
           REGISTRY_STAGE: ${{ steps.login-ecr-stage.outputs.registry }}
           REGISTRY_PROD: ${{ steps.login-ecr-prod.outputs.registry }}
-          REPOSITORY: ${{ inputs.ECR_PROD }}
+          REPOSITORY_STAGE: ${{ inputs.ECR_STAGE }}
+          REPOSITORY_PROD: ${{ inputs.ECR_PROD }}
           TAG_SHA: ${{ steps.tags.outputs.tag_sha }}
           TAG_RELEASE: ${{ steps.tags.outputs.tag_release }}
         run: |
-          docker tag $REGISTRY_STAGE/$REPOSITORY:latest $REGISTRY_PROD/$REPOSITORY:latest
-          docker tag $REGISTRY_STAGE/$REPOSITORY:latest $REGISTRY_PROD/$REPOSITORY:$TAG_SHA
-          docker tag $REGISTRY_STAGE/$REPOSITORY:latest $REGISTRY_PROD/$REPOSITORY:$TAG_RELEASE
-          docker push $REGISTRY_PROD/$REPOSITORY:latest
-          docker push $REGISTRY_PROD/$REPOSITORY:$TAG_SHA
-          docker push $REGISTRY_PROD/$REPOSITORY:$TAG_RELEASE
+          docker tag ${{ env.REGISTRY_STAGE }}/${{ env.REPOSITORY_STAGE }}:${GITHUB_SHA::8} ${{ env.REGISTRY_PROD }}/${{ env.REPOSITORY_PROD }}:latest
+          docker tag ${{ env.REGISTRY_STAGE }}/${{ env.REPOSITORY_STAGE }}:${GITHUB_SHA::8} ${{ env.REGISTRY_PROD }}/${{ env.REPOSITORY_PROD }}:$TAG_SHA
+          if [ $GITHUB_EVENT_NAME != "workflow_dispatch" ]; then
+            docker tag ${{ env.REGISTRY_STAGE }}/${{ env.REPOSITORY_STAGE }}:${GITHUB_SHA::8} ${{ env.REGISTRY_PROD }}/${{ env.REPOSITORY_PROD }}:$TAG_RELEASE
+          fi
+            docker push ${{ env.REGISTRY_PROD }}/${{ env.REPOSITORY_PROD }}:latest
+          docker push ${{ env.REGISTRY_PROD }}/${{ env.REPOSITORY_PROD }}:$TAG_SHA
+          if [ $GITHUB_EVENT_NAME != "workflow_dispatch" ]; then
+            docker push ${{ env.REGISTRY_PROD }}/${{ env.REPOSITORY_PROD }}:$TAG_RELEASE
+          fi
+          echo "#### Promote Container to Production" >> $GITHUB_STEP_SUMMARY
+          echo "✅ Promoted image to Prod ECR:" >> $GITHUB_STEP_SUMMARY
+          echo "- latest" >> $GITHUB_STEP_SUMMARY
+          echo "- $TAG_SHA" >> $GITHUB_STEP_SUMMARY
+          if [ $GITHUB_EVENT_NAME != "workflow_dispatch" ]; then
+            echo "- $TAG_RELEASE" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "- MANUAL RUN" >> $GITHUB_STEP_SUMMARY
+          fi
 
       - name: Update Lambda Function in Prod
         # Only update the Lambda Function if the container is destined for Lambda
         if: ${{ inputs.FUNCTION != '' && steps.check_sha.outputs.sha_match == 'true' }}
+        env:
+          REGISTRY_PROD: ${{ steps.login-ecr-prod.outputs.registry }}
+          REPOSITORY_PROD: ${{ inputs.ECR_PROD }}
         run: | 
           aws lambda update-function-code \
             --function-name ${{ inputs.FUNCTION }} \
-            --image-uri $REGISTRY_PROD/$REPOSITORY:latest \
+            --image-uri ${{ env.REGISTRY_PROD }}/${{ env.REPOSITORY_PROD }}:latest \
             --query "LastUpdateStatusReasonCode" \
             --output text
+          echo "#### Lambda Function" >> $GITHUB_STEP_SUMMARY
+          echo "✅ Lambda Function Updated" >> $GITHUB_STEP_SUMMARY

--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ The container that is pushed to the AWS ECR Repository in Stage-Workloads is tag
 - the short (8 character) SHA of the merge commit
 - the word "latest"
 
+The workflow requires a `CPU_ARCH` input. This is used to pick the GitHub-hosted runner architecture for the whole job and then it is used during the Docker build step to build the container for the correct architecture. See [partner-runner-images](https://github.com/actions/partner-runner-images?tab=readme-ov-file) for information related to `ARM64` based hosted runners.
+
 ### ecr-multi-arch-promote-prod.yml
 
 The promote to prod workflow just copies the container from stage to prod to ensure that there is no difference at all in what is deployed.


### PR DESCRIPTION
### Why these changes are being introduced

We are moving toward ARM64 CPU architecture across all of our workloads in AWS for cost and performance improvements. The existing shared workflows for deploying  containers to AWS ECR Repositories had AMD64/X86_64 baked in with no option for ARM64. The new workflows introduced with this PR can support either AMD64 or ARM64 CPU architectures.

Multiple rounds of testing were done using the [ecr-workflow-test](https://github.com/MITLibraries/ecr-workflow-test) repository to ensure that these new workflows will work as promised. A reviewer can visit the [Actions](https://github.com/MITLibraries/ecr-workflow-test/actions) tab for that repository and view all various runs for opening PRs (which triggers a deploy to Dev), merging PRs to `main` (which triggers a deploy to Stage), and tagging releases on `main` (which triggers a promotion of the stage container to prod).

I have left in place, without too much squashing, the history of commits that show the attempts using `docker buildx` and then the return to just regular `docker build` in a bash shell.

Full documentation for the migration path for container repositories that will call these shared workflows will be written after this is merged to `main`. Preliminary documentation can be found at [Work Plan: Support X86_64 or ARM64 for containers](https://mitlibraries.atlassian.net/wiki/x/BYCwGwE) in Confluence.

### How this addresses that need

* Introduce a `CODEOWNERS` file so that we can explicitly associate workflows to teams to automate who will get tagged when pull requests are opened for changes to shared workflows
* Create three new workflows for dev, stage, and prod deployments of containers
* Document the changes in the README
* No changes were made to the current/existing shared workflows, so all our container repositories will continue to work unchanged.

### Side effects of this change

None - these are totally separate workflows so there is no impact on any of the existing shared workflows.

### Relevant ticket(s)


* [IN-1445](https://mitlibraries.atlassian.net/browse/IN-1445)
* [IN-1446](https://mitlibraries.atlassian.net/browse/IN-1446)
* [IN-1447](https://mitlibraries.atlassian.net/browse/IN-1447)


[IN-1445]: https://mitlibraries.atlassian.net/browse/IN-1445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IN-1446]: https://mitlibraries.atlassian.net/browse/IN-1446?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IN-1447]: https://mitlibraries.atlassian.net/browse/IN-1447?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ