### PR TITLE
Created shared GitHub Actions workflows for uv-dependent Python apps

### DIFF
--- a/.github/workflows/python-uv-shared-lint.yml
+++ b/.github/workflows/python-uv-shared-lint.yml
@@ -1,0 +1,30 @@
+# This workflow runs linters on the repo 
+# with uv as the Python package and project manager
+
+# Requirements: Calling repo must 
+# - specify the Python version in a .python-version file or in a pyproject.toml
+# - contain a Makefile with a `make lint` command.
+
+name: Python Shared Linting Workflow
+
+on: 
+  pull_request:
+    paths-ignore:
+        - '.github/**'
+  workflow_call:
+  
+jobs:
+  lint:
+    name: Run linters
+    runs-on: ubuntu-latest
+    steps: 
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Create virtual environment
+        run: make install
+      
+      - name: Lint
+        run: make lint

--- a/.github/workflows/python-uv-shared-test.yml
+++ b/.github/workflows/python-uv-shared-test.yml
@@ -1,0 +1,38 @@
+# This workflow runs tests and sends a coverage report to Coveralls
+# with uv as the Python package and project manager
+
+# Requirements: Calling repo must
+# - specify the Python version in a .python-version file or in a pyproject.toml
+# - contain a Makefile with `make test` and `make coveralls` commands.
+
+name: Python Shared Test Workflow
+
+on: 
+  pull_request:
+    paths-ignore:
+      - '.github/**'
+  workflow_call:
+
+jobs:
+  test: 
+    name: Run tests and report coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+      
+      - name: Create virtual environment
+        run: make install
+      
+      - name: Run tests and make coverage report
+        run: |
+          make test
+          make coveralls
+      
+      - name: Coveralls
+        uses: coverallsapp/github-action@v2.3.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          fail-on-error: false


### PR DESCRIPTION
### Why these changes are being introduced:
[`uv`](https://docs.astral.sh/uv/) is recommended as the package and project manager for Python apps moving forward. This requires configuring shared workflows for automated testing and linting with GitHub actions.

### How this addresses that need:
Create shared workflows for testing and linting

### Side effects of this change:
The current naming conventions suggest `pipenv` as the default.

Relevant ticket(s):
* https://mitlibraries.atlassian.net/browse/IN-1538