### PR TITLE
Update shared GitHub action workflows for uv

### DIFF
--- a/.github/workflows/python-uv-shared-lint.yml
+++ b/.github/workflows/python-uv-shared-lint.yml
@@ -7,11 +7,7 @@
 
 name: Python Shared Linting Workflow
 
-on: 
-  pull_request:
-    paths-ignore:
-        - '.github/**'
-  workflow_call:
+on: workflow_call
   
 jobs:
   lint:

--- a/.github/workflows/python-uv-shared-test.yml
+++ b/.github/workflows/python-uv-shared-test.yml
@@ -7,11 +7,7 @@
 
 name: Python Shared Test Workflow
 
-on: 
-  pull_request:
-    paths-ignore:
-      - '.github/**'
-  workflow_call:
+on: workflow_call
 
 jobs:
   test: 


### PR DESCRIPTION
### Why these changes are being introduced

The `on` configurations for the shared testing and linting workflows for uv-dependent Python apps are simplified such that specific event triggers are set in the Python app template repos instead.

### How this addresses that need

Set `on: workflow_call`

### Side effects of this change

None

### Relevant ticket(s)

https://mitlibraries.atlassian.net/browse/IN-1538
