### PR TITLE
Container deploy improvements

### DIFF
--- a/.github/workflows/ecr-multi-arch-deploy-dev.yml
+++ b/.github/workflows/ecr-multi-arch-deploy-dev.yml
@@ -17,6 +17,10 @@ on:
       ECR:
         required: true
         type: string
+      DOCKERFILE:
+        default: 'Dockerfile'
+        required: false
+        type: string
       FUNCTION:
         required: false
         type: string
@@ -113,12 +117,14 @@ jobs:
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           REPOSITORY: ${{ inputs.ECR }}
+          DOCKERFILE: ${{ inputs.DOCKERFILE }}
           TAG_SHA: ${{ steps.tags.outputs.tag_sha }}
           TAG_PR: ${{ steps.tags.outputs.tag_pr }}
           TAG_LATEST: ${{ steps.tags.outputs.tag_latest }}
         run: |
           echo "### :whale: Docker Build" >> $GITHUB_STEP_SUMMARY
           DOCKER_BUILDKIT=1 docker build \
+            -f ${{ env.DOCKERFILE }} \
             -t ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:${{ env.TAG_LATEST }} \
             -t ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:${{ env.TAG_SHA }} \
             -t ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:${{ env.TAG_PR }} \
@@ -127,7 +133,7 @@ jobs:
           docker push ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:${{ env.TAG_SHA }}
           docker push ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:${{ env.TAG_PR }}
           
-          echo "✅ Successfully built and deployed the container." >> $GITHUB_STEP_SUMMARY
+          echo "✅ Successfully built and deployed the container from ${{ env.DOCKERFILE }}." >> $GITHUB_STEP_SUMMARY
           echo "**Platform**: \`${{ inputs.CPU_ARCH }}\`" >> $GITHUB_STEP_SUMMARY
           echo "**Tags**:" >> $GITHUB_STEP_SUMMARY
           echo "- \`${{ env.TAG_LATEST }}\`" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ecr-multi-arch-deploy-dev.yml
+++ b/.github/workflows/ecr-multi-arch-deploy-dev.yml
@@ -48,7 +48,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Check Python or Ruby
         id: buildcheck
@@ -87,7 +87,7 @@ jobs:
         # Run the Python setup only when there is a .python-version file in the root
         # of the repository. Otherwise, this step is skipped.
         if: ${{ steps.buildcheck.outputs.python_repo == '1' }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with: 
           python-version-file: '.python-version'
 
@@ -104,7 +104,7 @@ jobs:
         run: ${{ inputs.PREBUILD }}
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: ${{ inputs.AWS_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCT_DEV }}:role/${{ inputs.GHA_ROLE }}

--- a/.github/workflows/ecr-multi-arch-deploy-dev.yml
+++ b/.github/workflows/ecr-multi-arch-deploy-dev.yml
@@ -49,6 +49,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Check Python or Ruby
         id: buildcheck
@@ -66,8 +68,10 @@ jobs:
       - name: Create tags
         # Extra effort on tagging is necessary because GHA checkout uses a "detached head" 
         id: tags
+        env:
+          CPU_ARCH: ${{ inputs.CPU_ARCH }}
         run: |
-          CLEANED_ARCH=$(echo ${{ inputs.CPU_ARCH }} | cut -d'/' -f2)
+          CLEANED_ARCH=$(echo ${CPU_ARCH} | cut -d'/' -f2)
           if [ $GITHUB_EVENT_NAME = "workflow_dispatch" ]; then
             TAG_SHA=$(echo $GITHUB_SHA | cut -c 1-8) && \
             TAG_PR=$GITHUB_EVENT_NAME
@@ -101,7 +105,9 @@ jobs:
         # Only run this step if the app developer has specified "pre-build" commands
         # in the caller workflow.
         if: ${{ inputs.PREBUILD != '' }} 
-        run: ${{ inputs.PREBUILD }}
+        env:
+          PREBUILD: ${{ inputs.PREBUILD }}
+        run: ${PREBUILD}
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
@@ -118,39 +124,41 @@ jobs:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           REPOSITORY: ${{ inputs.ECR }}
           DOCKERFILE: ${{ inputs.DOCKERFILE }}
+          CPU_ARCH: ${{ inputs.CPU_ARCH }}
           TAG_SHA: ${{ steps.tags.outputs.tag_sha }}
           TAG_PR: ${{ steps.tags.outputs.tag_pr }}
           TAG_LATEST: ${{ steps.tags.outputs.tag_latest }}
         run: |
           echo "### :whale: Docker Build" >> $GITHUB_STEP_SUMMARY
           DOCKER_BUILDKIT=1 docker build \
-            -f ${{ env.DOCKERFILE }} \
-            -t ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:${{ env.TAG_LATEST }} \
-            -t ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:${{ env.TAG_SHA }} \
-            -t ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:${{ env.TAG_PR }} \
+            -f ${DOCKERFILE} \
+            -t ${REGISTRY}/${REPOSITORY}:${TAG_LATEST} \
+            -t ${REGISTRY}/${REPOSITORY}:${TAG_SHA} \
+            -t ${REGISTRY}/${REPOSITORY}:${TAG_PR} \
             .
-          docker push ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:${{ env.TAG_LATEST }}
-          docker push ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:${{ env.TAG_SHA }}
-          docker push ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:${{ env.TAG_PR }}
+          docker push ${REGISTRY}/${REPOSITORY}:${TAG_LATEST}
+          docker push ${REGISTRY}/${REPOSITORY}:${TAG_SHA}
+          docker push ${REGISTRY}/${REPOSITORY}:${TAG_PR}
           
-          echo "✅ Successfully built and deployed the container from ${{ env.DOCKERFILE }}." >> $GITHUB_STEP_SUMMARY
-          echo "**Platform**: \`${{ inputs.CPU_ARCH }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "✅ Successfully built and deployed the container from ${DOCKERFILE}." >> $GITHUB_STEP_SUMMARY
+          echo "**Platform**: \`${CPU_ARCH}\`" >> $GITHUB_STEP_SUMMARY
           echo "**Tags**:" >> $GITHUB_STEP_SUMMARY
-          echo "- \`${{ env.TAG_LATEST }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- \`${{ env.TAG_SHA }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- \`${{ env.TAG_PR }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- \`${TAG_LATEST}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- \`${TAG_SHA}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- \`${TAG_PR}\`" >> $GITHUB_STEP_SUMMARY
 
       - name: Update Lambda Function
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           REPOSITORY: ${{ inputs.ECR }}
           TAG_LATEST: ${{ steps.tags.outputs.tag_latest }}
+          FUNCTION: ${{ inputs.FUNCTION }}
         # Only update the Lambda Function if the developer passes in the Lambda Function name
         if: ${{ inputs.FUNCTION != '' }}
         run: |
           echo "### λ Lambda Update" >> $GITHUB_STEP_SUMMARY
           aws lambda update-function-code \
-            --function-name ${{ inputs.FUNCTION }} \
-            --image-uri ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:${{ env.TAG_LATEST }} \
+            --function-name ${FUNCTION} \
+            --image-uri ${REGISTRY}/${REPOSITORY}:${TAG_LATEST} \
             --query "LastUpdateStatusReasonCode" --output text
-          echo "✅ The Lambda function definition for \`${{ inputs.FUNCTION }}\` has been updated in Dev." >> $GITHUB_STEP_SUMMARY
+          echo "✅ The Lambda function definition for \`${FUNCTION}\` has been updated in Dev." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ecr-multi-arch-deploy-stage.yml
+++ b/.github/workflows/ecr-multi-arch-deploy-stage.yml
@@ -48,7 +48,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Check Python or Ruby
         id: buildcheck
@@ -80,7 +80,7 @@ jobs:
         # Run the Python setup only when there is a .python-version file in the root
         # of the repository. Otherwise, this step is skipped.
         if: ${{ steps.buildcheck.outputs.python_repo == '1' }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with: 
           python-version-file: '.python-version'
 
@@ -97,7 +97,7 @@ jobs:
         run: ${{ inputs.PREBUILD }}
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: ${{ inputs.AWS_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCT_STAGE }}:role/${{ inputs.GHA_ROLE }}

--- a/.github/workflows/ecr-multi-arch-deploy-stage.yml
+++ b/.github/workflows/ecr-multi-arch-deploy-stage.yml
@@ -49,6 +49,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Check Python or Ruby
         id: buildcheck
@@ -66,8 +68,10 @@ jobs:
       - name: Create tags
         # Extra effort on tagging is necessary because GHA checkout uses a "detached head" 
         id: tags
+        env:
+          CPU_ARCH: ${{ inputs.CPU_ARCH }}
         run: |
-          CLEANED_ARCH=$(echo ${{ inputs.CPU_ARCH }} | cut -d'/' -f2)
+          CLEANED_ARCH=$(echo ${CPU_ARCH} | cut -d'/' -f2)
           TAG_SHA=$(echo $GITHUB_SHA | cut -c 1-8)
           echo "tag_sha=${TAG_SHA}" >> $GITHUB_OUTPUT
           if [[ -f ".aws-architecture" ]]; then
@@ -94,7 +98,9 @@ jobs:
         # Only run this step if the app developer has specified "pre-build" commands
         # in the caller workflow.
         if: ${{ inputs.PREBUILD != '' }} 
-        run: ${{ inputs.PREBUILD }}
+        env:
+          PREBUILD: ${{ inputs.PREBUILD }}
+        run: ${PREBUILD}
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
@@ -116,30 +122,31 @@ jobs:
         run: |
           echo "### :whale: Docker Build" >> $GITHUB_STEP_SUMMARY
           DOCKER_BUILDKIT=1 docker build \
-            -f ${{ env.DOCKERFILE }} \
-            -t ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:${{ env.TAG_LATEST }} \
-            -t ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:${{ env.TAG_SHA }} \
+            -f ${DOCKERFILE} \
+            -t ${REGISTRY}/${REPOSITORY}:${TAG_LATEST} \
+            -t ${REGISTRY}/${REPOSITORY}:${TAG_SHA} \
             .
-          docker push ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:${{ env.TAG_LATEST }}
-          docker push ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:${{ env.TAG_SHA }}
+          docker push ${REGISTRY}/${REPOSITORY}:${TAG_LATEST}
+          docker push ${REGISTRY}/${REPOSITORY}:${TAG_SHA}
           
-          echo "✅ Successfully built and deployed the container from ${{ env.DOCKERFILE }}." >> $GITHUB_STEP_SUMMARY
-          echo "**Platform**: \`${{ inputs.CPU_ARCH }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "✅ Successfully built and deployed the container from ${DOCKERFILE}." >> $GITHUB_STEP_SUMMARY
+          echo "**Platform**: \` \`" >> $GITHUB_STEP_SUMMARY
           echo "**Tags**:" >> $GITHUB_STEP_SUMMARY
-          echo "- \`${{ env.TAG_LATEST }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- \`${{ env.TAG_SHA }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- \`${TAG_LATEST}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- \`${TAG_SHA}\`" >> $GITHUB_STEP_SUMMARY
 
       - name: Update Lambda Function
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           REPOSITORY: ${{ inputs.ECR }}
           TAG_LATEST: ${{ steps.tags.outputs.tag_latest }}
+          FUNCTION: ${{ inputs.FUNCTION }}
         # Only update the Lambda Function if the developer passes in the Lambda Function name
         if: ${{ inputs.FUNCTION != '' }}
         run: |
           echo "### λ Lambda Update" >> $GITHUB_STEP_SUMMARY
           aws lambda update-function-code \
-            --function-name ${{ inputs.FUNCTION }} \
-            --image-uri ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:${{ env.TAG_LATEST }} \
+            --function-name ${FUNCTION} \
+            --image-uri ${REGISTRY}/${REPOSITORY}:${TAG_LATEST} \
             --query "LastUpdateStatusReasonCode" --output text
-          echo "✅ The Lambda function definition for \`${{ inputs.FUNCTION }}\` has been updated in Stage." >> $GITHUB_STEP_SUMMARY
+          echo "✅ The Lambda function definition for \`${FUNCTION}\` has been updated in Stage." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ecr-multi-arch-deploy-stage.yml
+++ b/.github/workflows/ecr-multi-arch-deploy-stage.yml
@@ -17,6 +17,10 @@ on:
       ECR:
         required: true
         type: string
+      DOCKERFILE:
+        default: 'Dockerfile'
+        required: false
+        type: string
       FUNCTION:
         required: false
         type: string
@@ -106,18 +110,20 @@ jobs:
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           REPOSITORY: ${{ inputs.ECR }}
+          DOCKERFILE: ${{ inputs.DOCKERFILE }}
           TAG_SHA: ${{ steps.tags.outputs.tag_sha }}
           TAG_LATEST: ${{ steps.tags.outputs.tag_latest }}
         run: |
           echo "### :whale: Docker Build" >> $GITHUB_STEP_SUMMARY
           DOCKER_BUILDKIT=1 docker build \
+            -f ${{ env.DOCKERFILE }} \
             -t ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:${{ env.TAG_LATEST }} \
             -t ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:${{ env.TAG_SHA }} \
             .
           docker push ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:${{ env.TAG_LATEST }}
           docker push ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:${{ env.TAG_SHA }}
           
-          echo "✅ Successfully built and deployed the container." >> $GITHUB_STEP_SUMMARY
+          echo "✅ Successfully built and deployed the container from ${{ env.DOCKERFILE }}." >> $GITHUB_STEP_SUMMARY
           echo "**Platform**: \`${{ inputs.CPU_ARCH }}\`" >> $GITHUB_STEP_SUMMARY
           echo "**Tags**:" >> $GITHUB_STEP_SUMMARY
           echo "- \`${{ env.TAG_LATEST }}\`" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ecr-multi-arch-promote-prod.yml
+++ b/.github/workflows/ecr-multi-arch-promote-prod.yml
@@ -51,6 +51,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Configure AWS credentials for Stage
         id: login-aws-stage
@@ -61,8 +63,10 @@ jobs:
 
       - name: Set Architecture
         id: cpu_arch
+        env:
+          CPU_ARCH: ${{ inputs.CPU_ARCH }}
         run: |
-          CLEANED_ARCH=$(echo ${{ inputs.CPU_ARCH }} | cut -d'/' -f2)
+          CLEANED_ARCH=$(echo ${CPU_ARCH} | cut -d'/' -f2)
           if [[ -f ".aws-architecture" ]]; then
             echo "tag_latest=latest-${CLEANED_ARCH}" >> $GITHUB_OUTPUT
           else
@@ -78,7 +82,7 @@ jobs:
           REPOSITORY: ${{ inputs.ECR_STAGE }}
           TAG_LATEST: ${{ steps.cpu_arch.outputs.tag_latest }}
         run: |
-          export ECR_SHA=$(aws ecr describe-images --repository-name $REPOSITORY --image-ids imageTag=${{ env.TAG_LATEST }} --query 'imageDetails[].imageTags' | sed -E 's/[^a-zA-Z0-9]/\n/g' | grep -E '^[a-f0-9]{8}$')
+          export ECR_SHA=$(aws ecr describe-images --repository-name $REPOSITORY --image-ids imageTag=${TAG_LATEST} --query 'imageDetails[].imageTags' | sed -E 's/[^a-zA-Z0-9]/\n/g' | grep -E '^[a-f0-9]{8}$')
           if [[ ${GITHUB_SHA::8} == $ECR_SHA ]]; then
             echo "sha_match=true" >> $GITHUB_OUTPUT
             echo "### SHA Match Success" >> $GITHUB_STEP_SUMMARY
@@ -86,7 +90,7 @@ jobs:
           else
             echo "sha_match=false" >> $GITHUB_OUTPUT
             echo "### SHA Match Failure" >> $GITHUB_STEP_SUMMARY
-            echo "FAILURE: Stage-Workloads SHA did not match the default branch (${{ env.DEFAULT_BRANCH }})." >> $GITHUB_STEP_SUMMARY
+            echo "FAILURE: Stage-Workloads SHA did not match the default branch (${DEFAULT_BRANCH})." >> $GITHUB_STEP_SUMMARY
             exit 1
           fi
 
@@ -108,7 +112,7 @@ jobs:
           REGISTRY: ${{ steps.login-ecr-stage.outputs.registry }}
           REPOSITORY: ${{ inputs.ECR_STAGE }}
           TAG_SHA: ${{ steps.tags.outputs.tag_sha }}
-        run: docker pull ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:${{ env.TAG_SHA }}
+        run: docker pull ${REGISTRY}/${REPOSITORY}:${TAG_SHA}
 
       - name: Configure AWS credentials for Prod
         if: ${{ steps.check_sha.outputs.sha_match == 'true' }}
@@ -135,22 +139,22 @@ jobs:
           TAG_LATEST: ${{ steps.cpu_arch.outputs.tag_latest }}
         run: |
           echo "### :whale: Promote Container to Production" >> $GITHUB_STEP_SUMMARY
-          docker tag ${{ env.REGISTRY_STAGE }}/${{ env.REPOSITORY_STAGE }}:${{ env.TAG_SHA }} ${{ env.REGISTRY_PROD }}/${{ env.REPOSITORY_PROD }}:${{ env.TAG_LATEST }}
-          docker tag ${{ env.REGISTRY_STAGE }}/${{ env.REPOSITORY_STAGE }}:${{ env.TAG_SHA }} ${{ env.REGISTRY_PROD }}/${{ env.REPOSITORY_PROD }}:${{ env.TAG_SHA }}
-          docker push ${{ env.REGISTRY_PROD }}/${{ env.REPOSITORY_PROD }}:${{ env.TAG_LATEST }}
-          docker push ${{ env.REGISTRY_PROD }}/${{ env.REPOSITORY_PROD }}:${{ env.TAG_SHA }}
+          docker tag ${REGISTRY_STAGE}/${REPOSITORY_STAGE}:${TAG_SHA} ${REGISTRY_PROD}/${REPOSITORY_PROD}:${TAG_LATEST}
+          docker tag ${REGISTRY_STAGE}/${REPOSITORY_STAGE}:${TAG_SHA} ${REGISTRY_PROD}/${REPOSITORY_PROD}:${TAG_SHA}
+          docker push ${REGISTRY_PROD}/${REPOSITORY_PROD}:${TAG_LATEST}
+          docker push ${REGISTRY_PROD}/${REPOSITORY_PROD}:${TAG_SHA}
           
           echo "✅ Promoted image to Prod ECR with the following tags:" >> $GITHUB_STEP_SUMMARY
-          echo "- \`${{ env.TAG_LATEST }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- \`${{ env.TAG_SHA }}\` (GitHub SHA)" >> $GITHUB_STEP_SUMMARY
+          echo "- \`${TAG_LATEST}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- \`${TAG_SHA}\` (GitHub SHA)" >> $GITHUB_STEP_SUMMARY
 
           if [ $GITHUB_EVENT_NAME != "workflow_dispatch" ]; then
-            docker tag ${{ env.REGISTRY_STAGE }}/${{ env.REPOSITORY_STAGE }}:${GITHUB_SHA::8} ${{ env.REGISTRY_PROD }}/${{ env.REPOSITORY_PROD }}:${{ env.TAG_RELEASE }}
-            docker push ${{ env.REGISTRY_PROD }}/${{ env.REPOSITORY_PROD }}:${{ env.TAG_RELEASE }}
-            echo "- \`${{ env.TAG_RELEASE }}\` (GitHub Release Version)" >> $GITHUB_STEP_SUMMARY
+            docker tag ${REGISTRY_STAGE}/${REPOSITORY_STAGE}:${GITHUB_SHA::8} ${REGISTRY_PROD}/${REPOSITORY_PROD}:${TAG_RELEASE}
+            docker push ${REGISTRY_PROD}/${REPOSITORY_PROD}:${TAG_RELEASE}
+            echo "- \`${TAG_RELEASE}\` (GitHub Release Version)" >> $GITHUB_STEP_SUMMARY
           else
-            docker tag ${{ env.REGISTRY_STAGE }}/${{ env.REPOSITORY_STAGE }}:${GITHUB_SHA::8} ${{ env.REGISTRY_PROD }}/${{ env.REPOSITORY_PROD }}:MANUAL_TRIGGER
-            docker push ${{ env.REGISTRY_PROD }}/${{ env.REPOSITORY_PROD }}:MANUAL_TRIGGER
+            docker tag ${REGISTRY_STAGE}/${REPOSITORY_STAGE}:${GITHUB_SHA::8} ${REGISTRY_PROD}/${REPOSITORY_PROD}:MANUAL_TRIGGER
+            docker push ${REGISTRY_PROD}/${REPOSITORY_PROD}:MANUAL_TRIGGER
             echo "- \`MANUAL_TRIGGER\`" >> $GITHUB_STEP_SUMMARY
           fi
 
@@ -161,10 +165,11 @@ jobs:
           REGISTRY_PROD: ${{ steps.login-ecr-prod.outputs.registry }}
           REPOSITORY_PROD: ${{ inputs.ECR_PROD }}
           TAG_LATEST: ${{ steps.cpu_arch.outputs.tag_latest }}
+          FUNCTION: ${{ inputs.FUNCTION }}
         run: | 
           aws lambda update-function-code \
-            --function-name ${{ inputs.FUNCTION }} \
-            --image-uri ${{ env.REGISTRY_PROD }}/${{ env.REPOSITORY_PROD }}:${{ env.TAG_LATEST }} \
+            --function-name ${FUNCTION} \
+            --image-uri ${REGISTRY_PROD}/${REPOSITORY_PROD}:${TAG_LATEST} \
             --query "LastUpdateStatusReasonCode" \
             --output text
           echo "### λ Lambda Function" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ecr-multi-arch-promote-prod.yml
+++ b/.github/workflows/ecr-multi-arch-promote-prod.yml
@@ -20,6 +20,10 @@ on:
       ECR_PROD:
         required: true
         type: string
+      DEFAULT_BRANCH:
+        default: 'main'
+        required: false
+        type: string
       CPU_ARCH: # either linux/arm64 or linux/amd64
         required: true
         type: string
@@ -39,7 +43,7 @@ defaults:
 
 jobs:
   promote:
-    if: ${{ github.ref == 'refs/heads/main' || github.event.release.target_commitish == 'main' }}
+    if: ${{ github.event.release.target_commitish == inputs.DEFAULT_BRANCH }}
     name: Promote to Prod
     # E.g., download from Stage then upload to Prod
     runs-on: ubuntu-latest
@@ -66,10 +70,11 @@ jobs:
           fi
 
       - name: Check SHAs
-        # A fail-safe check to verify that the SHAs match between the `main` branch and
+        # A fail-safe check to verify that the SHAs match between the default branch and
         # the ECR currently in Stage-Workloads
         id: check_sha
         env:
+          DEFAULT_BRANCH: ${{ inputs.DEFAULT_BRANCH }}
           REPOSITORY: ${{ inputs.ECR_STAGE }}
           TAG_LATEST: ${{ steps.cpu_arch.outputs.tag_latest }}
         run: |
@@ -81,7 +86,7 @@ jobs:
           else
             echo "sha_match=false" >> $GITHUB_OUTPUT
             echo "### SHA Match Failure" >> $GITHUB_STEP_SUMMARY
-            echo "FAILURE: Stage-Workloads SHA did not match the main branch." >> $GITHUB_STEP_SUMMARY
+            echo "FAILURE: Stage-Workloads SHA did not match the default branch (${{ env.DEFAULT_BRANCH }})." >> $GITHUB_STEP_SUMMARY
             exit 1
           fi
 

--- a/.github/workflows/ecr-multi-arch-promote-prod.yml
+++ b/.github/workflows/ecr-multi-arch-promote-prod.yml
@@ -50,11 +50,11 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Configure AWS credentials for Stage
         id: login-aws-stage
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: ${{ inputs.AWS_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCT_STAGE }}:role/${{ inputs.GHA_ROLE_STAGE }}
@@ -113,7 +113,7 @@ jobs:
       - name: Configure AWS credentials for Prod
         if: ${{ steps.check_sha.outputs.sha_match == 'true' }}
         id: login-aws-prod
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: ${{ inputs.AWS_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCT_PROD }}:role/${{ inputs.GHA_ROLE_PROD }}


### PR DESCRIPTION
### Why these changes are being introduced

The launch of quepid in AWS triggered necessary changes to the shared automated deployment workflows. The first round of deploys for queped used the changes in the feature branch, but they changes can be moved into the `main` branch because they do not *require* changes to the caller workflows.

### How this addresses that need

* In the dev and stage workflows, add a `DOCKERFILE` input variable to capture the name of the caller application's Dockerfile if it is something different than the standard `Dockerfile` (it will default to `Dockerfile` if no input is provided)
* In the prod workflow, add a `DEFAULT_BRANCH` input variable to capture the name of the caller applications's default branch if it is something different than the standard `main` (it will default to `main` if no input is provided)
* Update all the versions of the third party actions to the latest available version
* Address a number of warnings from `qltysh` for these three actions (addressing "code injection via template expansion" and "credential persistence through GitHub Actions artifacts")

This does not address the "unpinned actions reference" at this time.
 
### Side effects of this change

None. The two new input variables have default values, so no changes are required for calling workflows.

* [IN-1666](https://mitlibraries.atlassian.net/browse/IN-1666)


[IN-1666]: https://mitlibraries.atlassian.net/browse/IN-1666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ