### PR TITLE
Improve ECR Workflows

### DIFF
--- a/.github/workflows/ecr-multi-arch-deploy-dev.yml
+++ b/.github/workflows/ecr-multi-arch-deploy-dev.yml
@@ -52,6 +52,10 @@ jobs:
 
       - name: Set CPU Architecture
         id: setarch
+        # This checks for the existence of an `.aws-architecture` file in the application repository. If
+        # that file exists, it uses the file to determine the CPU architecture for the docker build. If
+        # the file does not exist, it defaults to `linux/amd64` which has been the default CPU architecture
+        # until recently. Finally, it exports this string for use in later jobs.
         run: |
           echo "### :abacus: Architecture Selection" >> $GITHUB_STEP_SUMMARY
           if [[ -f .aws-architecture ]]; then
@@ -71,7 +75,7 @@ jobs:
   build-push:
     name: Build and Push to AWS ECR on ${{ needs.prep.outputs.cpuarch }}
     needs: prep
-    # Pick a runner that matches the CPU architecture of the container
+    # Pick a runner that matches the CPU architecture of the container, based on the "prep" job
     runs-on: ${{ needs.prep.outputs.cpuarch == 'linux/arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest'  }}
     # This line adds a check for the user which is requesting the PR. As long as its not dependabot, we go ahead and run it.
     if: ${{ github.triggering_actor != 'dependabot[bot]' }}
@@ -98,10 +102,20 @@ jobs:
           fi
 
       - name: Create tags
-        # Extra effort on tagging is necessary because GHA checkout uses a "detached head"
         id: tags
         env:
           CPU_ARCH: ${{ needs.prep.outputs.cpuarch }}
+        # Extra effort on tagging is necessary because GHA checkout uses a "detached head". Here
+        # we create the tags we will need later when building and pushing the image to ECR in AWS.
+        # TAG_SHA and TAG_PR are constructed in slightly different ways if this run is triggered
+        # by a pull request versus triggered by workflow_dispatch from the Actions tab in GitHub.
+        # The TAG_LATEST depends on whether we are in "default AMD64" mode or in the specify the
+        # the CPU architecture via a .aws-architecture file mode. In the latter, we postpend the
+        # CPU type after `latest` so that it is very clear in ECR what CPU architecture is
+        # expected (and this allows us to use this workflow even for infrastructure that has not
+        # yet been updated to support different CPU architectures).
+        # NOTE: We strip the `linux/` from the CPU_ARCH because `docker` cannot handle slashes
+        # in tag names!
         run: |
           CLEANED_ARCH=$(echo ${CPU_ARCH} | cut -d'/' -f2)
           if [ $GITHUB_EVENT_NAME = "workflow_dispatch" ]; then

--- a/.github/workflows/ecr-multi-arch-deploy-dev.yml
+++ b/.github/workflows/ecr-multi-arch-deploy-dev.yml
@@ -1,5 +1,5 @@
 # ECS Container Deployment for Fargate & Lambda for both ARM64 and AMD64
-name: Dev Deploy Container Multi-Arch
+name: Dev Deploy Image Multi-Arch
 
 on:
   workflow_call:
@@ -12,7 +12,7 @@ on:
         required: true
         type: string
       CPU_ARCH: # either linux/arm64 or linux/amd64
-        required: true
+        required: false
         type: string
       ECR:
         required: true
@@ -39,12 +39,44 @@ permissions:
   contents: read
 
 jobs:
-  deploy:
-    name: AWS ECR on ${{ inputs.CPU_ARCH }}
+  prep:
+    name: Set CPU Architecture
+    runs-on: ubuntu-latest
+    outputs:
+      cpuarch: ${{ steps.setarch.outputs.cpuarch }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Set CPU Architecture
+        id: setarch
+        run: |
+          echo "### :abacus: Architecture Selection" >> $GITHUB_STEP_SUMMARY
+          if [[ -f .aws-architecture ]]; then
+            ARCH=$(cat .aws-architecture)
+            echo "\`$ARCH\` was read from \`.aws-architecture\` and passed to the deploy job." >> $GITHUB_STEP_SUMMARY
+          else
+            ARCH="linux/amd64"
+            echo "No \`.aws-architecture\` file, so default \`$ARCH\` was passed to the deploy job." >> $GITHUB_STEP_SUMMARY
+          fi
+          if [[ "$ARCH" != "linux/arm64" && "$ARCH" != "linux/amd64" ]]; then
+            echo "$ARCH is INVALID architecture!"
+            echo "$ARCH is INVALID architecture!" >> $GITHUB_STEP_SUMMARY
+            exit 1
+          fi
+          echo "cpuarch=$ARCH" >> $GITHUB_OUTPUT
+
+  build-push:
+    name: Build and Push to AWS ECR on ${{ needs.prep.outputs.cpuarch }}
+    needs: prep
     # Pick a runner that matches the CPU architecture of the container
-    runs-on: ${{ inputs.CPU_ARCH == 'linux/arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest'  }}
-    # This line adds a check for the user which is requesting the PR. As long as its not dependabot, we go ahead and run it. 
+    runs-on: ${{ needs.prep.outputs.cpuarch == 'linux/arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest'  }}
+    # This line adds a check for the user which is requesting the PR. As long as its not dependabot, we go ahead and run it.
     if: ${{ github.triggering_actor != 'dependabot[bot]' }}
+    outputs:
+      tag_latest: ${{ steps.tags.outputs.tag_latest}}
 
     steps:
       - name: Checkout code
@@ -66,10 +98,10 @@ jobs:
           fi
 
       - name: Create tags
-        # Extra effort on tagging is necessary because GHA checkout uses a "detached head" 
+        # Extra effort on tagging is necessary because GHA checkout uses a "detached head"
         id: tags
         env:
-          CPU_ARCH: ${{ inputs.CPU_ARCH }}
+          CPU_ARCH: ${{ needs.prep.outputs.cpuarch }}
         run: |
           CLEANED_ARCH=$(echo ${CPU_ARCH} | cut -d'/' -f2)
           if [ $GITHUB_EVENT_NAME = "workflow_dispatch" ]; then
@@ -92,11 +124,11 @@ jobs:
         # of the repository. Otherwise, this step is skipped.
         if: ${{ steps.buildcheck.outputs.python_repo == '1' }}
         uses: actions/setup-python@v6
-        with: 
-          python-version-file: '.python-version'
+        with:
+          python-version-file: ".python-version"
 
       - name: Get Ruby
-        # Run the Ruby setup setup only when there is a .ruby-version file in the 
+        # Run the Ruby setup setup only when there is a .ruby-version file in the
         # root of the repository. Otherwise, this step is skipped.
         if: ${{ steps.buildcheck.outputs.ruby_repo == '1' }}
         uses: ruby/setup-ruby@v1 # by default, this uses the .ruby-version file to set the version
@@ -104,7 +136,7 @@ jobs:
       - name: Run pre-build steps
         # Only run this step if the app developer has specified "pre-build" commands
         # in the caller workflow.
-        if: ${{ inputs.PREBUILD != '' }} 
+        if: ${{ inputs.PREBUILD != '' }}
         env:
           PREBUILD: ${{ inputs.PREBUILD }}
         run: ${PREBUILD}
@@ -119,12 +151,12 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
 
-      - name: Build and Push container
+      - name: Build and Push Image
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           REPOSITORY: ${{ inputs.ECR }}
           DOCKERFILE: ${{ inputs.DOCKERFILE }}
-          CPU_ARCH: ${{ inputs.CPU_ARCH }}
+          CPU_ARCH: ${{ needs.prep.outputs.cpuarch }}
           TAG_SHA: ${{ steps.tags.outputs.tag_sha }}
           TAG_PR: ${{ steps.tags.outputs.tag_pr }}
           TAG_LATEST: ${{ steps.tags.outputs.tag_latest }}
@@ -139,7 +171,7 @@ jobs:
           docker push ${REGISTRY}/${REPOSITORY}:${TAG_LATEST}
           docker push ${REGISTRY}/${REPOSITORY}:${TAG_SHA}
           docker push ${REGISTRY}/${REPOSITORY}:${TAG_PR}
-          
+
           echo "✅ Successfully built and deployed the container from ${DOCKERFILE}." >> $GITHUB_STEP_SUMMARY
           echo "**Platform**: \`${CPU_ARCH}\`" >> $GITHUB_STEP_SUMMARY
           echo "**Tags**:" >> $GITHUB_STEP_SUMMARY
@@ -147,11 +179,30 @@ jobs:
           echo "- \`${TAG_SHA}\`" >> $GITHUB_STEP_SUMMARY
           echo "- \`${TAG_PR}\`" >> $GITHUB_STEP_SUMMARY
 
+  deploy-lambda:
+    # Note: image-based Lambdas must be explicitly updated to load the latest image
+    #       into the Lambda Function.
+    # Only run this job if the Lambda Function name is passed from caller workflow
+    if: ${{ inputs.FUNCTION != '' }}
+    name: Deploy Lambda Function
+    runs-on: ubuntu-latest
+    needs: build-push
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          aws-region: ${{ inputs.AWS_REGION }}
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCT_DEV }}:role/${{ inputs.GHA_ROLE }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
       - name: Update Lambda Function
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           REPOSITORY: ${{ inputs.ECR }}
-          TAG_LATEST: ${{ steps.tags.outputs.tag_latest }}
+          TAG_LATEST: ${{ needs.build-push.outputs.tag_latest }}
           FUNCTION: ${{ inputs.FUNCTION }}
         # Only update the Lambda Function if the developer passes in the Lambda Function name
         if: ${{ inputs.FUNCTION != '' }}

--- a/.github/workflows/ecr-multi-arch-deploy-stage.yml
+++ b/.github/workflows/ecr-multi-arch-deploy-stage.yml
@@ -52,6 +52,10 @@ jobs:
 
       - name: Set CPU Architecture
         id: setarch
+        # This checks for the existence of an `.aws-architecture` file in the application repository. If
+        # that file exists, it uses the file to determine the CPU architecture for the docker build. If
+        # the file does not exist, it defaults to `linux/amd64` which has been the default CPU architecture
+        # until recently. Finally, it exports this string for use in later jobs.
         run: |
           echo "### :abacus: Architecture Selection" >> $GITHUB_STEP_SUMMARY
           if [[ -f .aws-architecture ]]; then
@@ -98,10 +102,19 @@ jobs:
           fi
 
       - name: Create tags
-        # Extra effort on tagging is necessary because GHA checkout uses a "detached head"
         id: tags
         env:
           CPU_ARCH: ${{ needs.prep.outputs.cpuarch }}
+        # Extra effort on tagging is necessary because GHA checkout uses a "detached head". Here
+        # we create the tags we will need later when building and pushing the image to ECR in AWS.
+        # TAG_SHA is pulled directly from the GHA environment and then shortened to eight characters.
+        # The TAG_LATEST depends on whether we are in "default AMD64" mode or in the specify the
+        # the CPU architecture via a .aws-architecture file mode. In the latter, we postpend the
+        # CPU type after `latest` so that it is very clear in ECR what CPU architecture is
+        # expected (and this allows us to use this workflow even for infrastructure that has not
+        # yet been updated to support different CPU architectures).
+        # NOTE: We strip the `linux/` from the CPU_ARCH because `docker` cannot handle slashes
+        # in tag names!
         run: |
           CLEANED_ARCH=$(echo ${CPU_ARCH} | cut -d'/' -f2)
           TAG_SHA=$(echo $GITHUB_SHA | cut -c 1-8)

--- a/.github/workflows/ecr-multi-arch-deploy-stage.yml
+++ b/.github/workflows/ecr-multi-arch-deploy-stage.yml
@@ -1,5 +1,5 @@
 # ECS Container Deployment for Fargate & Lambda for both ARM64 and AMD64
-name: Stage Deploy Container Multi-Arch
+name: Stage Deploy Image Multi-Arch
 
 on:
   workflow_call:
@@ -12,7 +12,7 @@ on:
         required: true
         type: string
       CPU_ARCH: # either linux/arm64 or linux/amd64
-        required: true
+        required: false
         type: string
       ECR:
         required: true
@@ -39,12 +39,44 @@ permissions:
   contents: read
 
 jobs:
-  deploy:
-    name: AWS ECR on ${{ inputs.CPU_ARCH }}
+  prep:
+    name: Set CPU Architecture
+    runs-on: ubuntu-latest
+    outputs:
+      cpuarch: ${{ steps.setarch.outputs.cpuarch }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Set CPU Architecture
+        id: setarch
+        run: |
+          echo "### :abacus: Architecture Selection" >> $GITHUB_STEP_SUMMARY
+          if [[ -f .aws-architecture ]]; then
+            ARCH=$(cat .aws-architecture)
+            echo "\`$ARCH\` was read from \`.aws-architecture\` and passed to the deploy job." >> $GITHUB_STEP_SUMMARY
+          else
+            ARCH="linux/amd64"
+            echo "No \`.aws-architecture\` file, so default \`$ARCH\` was passed to the deploy job." >> $GITHUB_STEP_SUMMARY
+          fi
+          if [[ "$ARCH" != "linux/arm64" && "$ARCH" != "linux/amd64" ]]; then
+            echo "$ARCH is INVALID architecture!"
+            echo "$ARCH is INVALID architecture!" >> $GITHUB_STEP_SUMMARY
+            exit 1
+          fi
+          echo "cpuarch=$ARCH" >> $GITHUB_OUTPUT
+
+  build-push:
+    name: Build and Push to AWS ECR on ${{ needs.prep.outputs.cpuarch }}
+    needs: prep
     # Pick a runner that matches the CPU architecture of the container
-    runs-on: ${{ inputs.CPU_ARCH == 'linux/arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest'  }}
-    # This line adds a check for the user which is requesting the PR. As long as its not dependabot, we go ahead and run it. 
+    runs-on: ${{ needs.prep.outputs.cpuarch == 'linux/arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest'  }}
+    # This line adds a check for the user which is requesting the PR. As long as its not dependabot, we go ahead and run it.
     if: ${{ github.triggering_actor != 'dependabot[bot]' }}
+    outputs:
+      tag_latest: ${{ steps.tags.outputs.tag_latest}}
 
     steps:
       - name: Checkout code
@@ -66,10 +98,10 @@ jobs:
           fi
 
       - name: Create tags
-        # Extra effort on tagging is necessary because GHA checkout uses a "detached head" 
+        # Extra effort on tagging is necessary because GHA checkout uses a "detached head"
         id: tags
         env:
-          CPU_ARCH: ${{ inputs.CPU_ARCH }}
+          CPU_ARCH: ${{ needs.prep.outputs.cpuarch }}
         run: |
           CLEANED_ARCH=$(echo ${CPU_ARCH} | cut -d'/' -f2)
           TAG_SHA=$(echo $GITHUB_SHA | cut -c 1-8)
@@ -85,11 +117,11 @@ jobs:
         # of the repository. Otherwise, this step is skipped.
         if: ${{ steps.buildcheck.outputs.python_repo == '1' }}
         uses: actions/setup-python@v6
-        with: 
-          python-version-file: '.python-version'
+        with:
+          python-version-file: ".python-version"
 
       - name: Get Ruby
-        # Run the Ruby setup setup only when there is a .ruby-version file in the 
+        # Run the Ruby setup setup only when there is a .ruby-version file in the
         # root of the repository. Otherwise, this step is skipped.
         if: ${{ steps.buildcheck.outputs.ruby_repo == '1' }}
         uses: ruby/setup-ruby@v1 # by default, this uses the .ruby-version file to set the version
@@ -97,7 +129,7 @@ jobs:
       - name: Run pre-build steps
         # Only run this step if the app developer has specified "pre-build" commands
         # in the caller workflow.
-        if: ${{ inputs.PREBUILD != '' }} 
+        if: ${{ inputs.PREBUILD != '' }}
         env:
           PREBUILD: ${{ inputs.PREBUILD }}
         run: ${PREBUILD}
@@ -112,11 +144,12 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
 
-      - name: Build and Push container
+      - name: Build and Push Image
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           REPOSITORY: ${{ inputs.ECR }}
           DOCKERFILE: ${{ inputs.DOCKERFILE }}
+          CPU_ARCH: ${{ needs.prep.outputs.cpuarch }}
           TAG_SHA: ${{ steps.tags.outputs.tag_sha }}
           TAG_LATEST: ${{ steps.tags.outputs.tag_latest }}
         run: |
@@ -128,18 +161,37 @@ jobs:
             .
           docker push ${REGISTRY}/${REPOSITORY}:${TAG_LATEST}
           docker push ${REGISTRY}/${REPOSITORY}:${TAG_SHA}
-          
+
           echo "✅ Successfully built and deployed the container from ${DOCKERFILE}." >> $GITHUB_STEP_SUMMARY
-          echo "**Platform**: \` \`" >> $GITHUB_STEP_SUMMARY
+          echo "**Platform**: \`${CPU_ARCH}\`" >> $GITHUB_STEP_SUMMARY
           echo "**Tags**:" >> $GITHUB_STEP_SUMMARY
           echo "- \`${TAG_LATEST}\`" >> $GITHUB_STEP_SUMMARY
           echo "- \`${TAG_SHA}\`" >> $GITHUB_STEP_SUMMARY
+
+  deploy-lambda:
+    # Note: image-based Lambdas must be explicitly updated to load the latest image
+    #       into the Lambda Function.
+    # Only run this job if the Lambda Function name is passed from caller workflow
+    if: ${{ inputs.FUNCTION != '' }}
+    name: Deploy Lambda Function
+    runs-on: ubuntu-latest
+    needs: build-push
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          aws-region: ${{ inputs.AWS_REGION }}
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCT_STAGE }}:role/${{ inputs.GHA_ROLE }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
 
       - name: Update Lambda Function
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           REPOSITORY: ${{ inputs.ECR }}
-          TAG_LATEST: ${{ steps.tags.outputs.tag_latest }}
+          TAG_LATEST: ${{ needs.build-push.outputs.tag_latest }}
           FUNCTION: ${{ inputs.FUNCTION }}
         # Only update the Lambda Function if the developer passes in the Lambda Function name
         if: ${{ inputs.FUNCTION != '' }}

--- a/.github/workflows/ecr-multi-arch-promote-prod.yml
+++ b/.github/workflows/ecr-multi-arch-promote-prod.yml
@@ -1,11 +1,11 @@
 # ECS Container Deployment for Fargate & Lambda for both ARM64 and AMD64
-name: Prod Promote Container Multi-Arch
+name: Prod Promote Image Multi-Arch
 
 on:
   workflow_call:
     inputs:
       AWS_REGION:
-        default: 'us-east-1'
+        default: "us-east-1"
         required: false
         type: string
       GHA_ROLE_STAGE:
@@ -21,32 +21,66 @@ on:
         required: true
         type: string
       DEFAULT_BRANCH:
-        default: 'main'
+        default: "main"
         required: false
         type: string
       CPU_ARCH: # either linux/arm64 or linux/amd64
-        required: true
+        required: false
         type: string
       FUNCTION:
         required: false
         type: string
-
-# These permissions are needed to interact with GitHub's OIDC Token endpoint.
-permissions:
-  id-token: write
-  contents: read
 
 # Set defaults
 defaults:
   run:
     shell: bash
 
+# These permissions are needed to interact with GitHub's OIDC Token endpoint.
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
+  prep:
+    if: ${{ github.event.release.target_commitish == inputs.DEFAULT_BRANCH }}
+    name: Set CPU Architecture
+    runs-on: ubuntu-latest
+    outputs:
+      cpuarch: ${{ steps.setarch.outputs.cpuarch }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Set CPU Architecture
+        id: setarch
+        run: |
+          echo "### :abacus: Architecture Selection" >> $GITHUB_STEP_SUMMARY
+          if [[ -f .aws-architecture ]]; then
+            ARCH=$(cat .aws-architecture)
+            echo "\`$ARCH\` was read from \`.aws-architecture\` and passed to the deploy job." >> $GITHUB_STEP_SUMMARY
+          else
+            ARCH="linux/amd64"
+            echo "No \`.aws-architecture\` file, so default \`$ARCH\` was passed to the deploy job." >> $GITHUB_STEP_SUMMARY
+          fi
+          if [[ "$ARCH" != "linux/arm64" && "$ARCH" != "linux/amd64" ]]; then
+            echo "$ARCH is INVALID architecture!"
+            echo "$ARCH is INVALID architecture!" >> $GITHUB_STEP_SUMMARY
+            exit 1
+          fi
+          echo "cpuarch=$ARCH" >> $GITHUB_OUTPUT
+
   promote:
     if: ${{ github.event.release.target_commitish == inputs.DEFAULT_BRANCH }}
     name: Promote to Prod
+    needs: prep
     # E.g., download from Stage then upload to Prod
     runs-on: ubuntu-latest
+    outputs:
+      tag_latest: ${{ steps.tags.outputs.tag_latest }}
+      sha_match: ${{ steps.check_sha.outputs.sha_match }}
 
     steps:
       - name: Checkout code
@@ -64,7 +98,7 @@ jobs:
       - name: Set Architecture
         id: cpu_arch
         env:
-          CPU_ARCH: ${{ inputs.CPU_ARCH }}
+          CPU_ARCH: ${{ needs.prep.outputs.cpuarch }}
         run: |
           CLEANED_ARCH=$(echo ${CPU_ARCH} | cut -d'/' -f2)
           if [[ -f ".aws-architecture" ]]; then
@@ -143,7 +177,7 @@ jobs:
           docker tag ${REGISTRY_STAGE}/${REPOSITORY_STAGE}:${TAG_SHA} ${REGISTRY_PROD}/${REPOSITORY_PROD}:${TAG_SHA}
           docker push ${REGISTRY_PROD}/${REPOSITORY_PROD}:${TAG_LATEST}
           docker push ${REGISTRY_PROD}/${REPOSITORY_PROD}:${TAG_SHA}
-          
+
           echo "✅ Promoted image to Prod ECR with the following tags:" >> $GITHUB_STEP_SUMMARY
           echo "- \`${TAG_LATEST}\`" >> $GITHUB_STEP_SUMMARY
           echo "- \`${TAG_SHA}\` (GitHub SHA)" >> $GITHUB_STEP_SUMMARY
@@ -158,15 +192,33 @@ jobs:
             echo "- \`MANUAL_TRIGGER\`" >> $GITHUB_STEP_SUMMARY
           fi
 
+  deploy-lambda:
+    # Note: image-based Lambdas must be explicitly updated to load the latest image
+    #       into the Lambda Function.
+    # Only run this job if the Lambda Function name is passed from caller workflow
+    if:
+      ${{ inputs.FUNCTION != '' && needs.promote.outputs.sha_match == 'true' }}
+    name: Deploy Lambda Function
+    runs-on: ubuntu-latest
+    needs: promote
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          aws-region: ${{ inputs.AWS_REGION }}
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCT_PROD }}:role/${{ inputs.GHA_ROLE_PROD }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr-prod
+        uses: aws-actions/amazon-ecr-login@v2
+
       - name: Update Lambda Function in Prod
-        # Only update the Lambda Function if the container is destined for Lambda
-        if: ${{ inputs.FUNCTION != '' && steps.check_sha.outputs.sha_match == 'true' }}
         env:
           REGISTRY_PROD: ${{ steps.login-ecr-prod.outputs.registry }}
           REPOSITORY_PROD: ${{ inputs.ECR_PROD }}
-          TAG_LATEST: ${{ steps.cpu_arch.outputs.tag_latest }}
+          TAG_LATEST: ${{ needs.promote.outputs.tag_latest }}
           FUNCTION: ${{ inputs.FUNCTION }}
-        run: | 
+        run: |
           aws lambda update-function-code \
             --function-name ${FUNCTION} \
             --image-uri ${REGISTRY_PROD}/${REPOSITORY_PROD}:${TAG_LATEST} \

--- a/.github/workflows/ecr-multi-arch-promote-prod.yml
+++ b/.github/workflows/ecr-multi-arch-promote-prod.yml
@@ -56,6 +56,10 @@ jobs:
 
       - name: Set CPU Architecture
         id: setarch
+        # This checks for the existence of an `.aws-architecture` file in the application repository. If
+        # that file exists, it uses the file to determine the CPU architecture for the docker build. If
+        # the file does not exist, it defaults to `linux/amd64` which has been the default CPU architecture
+        # until recently. Finally, it exports this string for use in later jobs.
         run: |
           echo "### :abacus: Architecture Selection" >> $GITHUB_STEP_SUMMARY
           if [[ -f .aws-architecture ]]; then
@@ -99,6 +103,13 @@ jobs:
         id: cpu_arch
         env:
           CPU_ARCH: ${{ needs.prep.outputs.cpuarch }}
+        # The TAG_LATEST depends on whether we are in "default AMD64" mode or in the specify the
+        # the CPU architecture via a .aws-architecture file mode. In the latter, we postpend the
+        # CPU type after `latest` so that it is very clear in ECR what CPU architecture is
+        # expected (and this allows us to use this workflow even for infrastructure that has not
+        # yet been updated to support different CPU architectures).
+        # NOTE: We strip the `linux/` from the CPU_ARCH because `docker` cannot handle slashes
+        # in tag names!
         run: |
           CLEANED_ARCH=$(echo ${CPU_ARCH} | cut -d'/' -f2)
           if [[ -f ".aws-architecture" ]]; then

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ There are three workflows associated with publishing Docker containers to AWS EC
 
 **Note**: *While these workflows publish containers to ECR they do ***NOT*** force ECS services to restart with the new container.*
 
-These workflows include an input variable that allows the developer to choose either `linux/amd64` or `linux/arm64` as the CPU architecture for the built container.
+These workflows include an input variable that allows the developer to choose either `linux/amd64` or `linux/arm64` as the CPU architecture for the built container. **Note**: We are moving away from this input variable in favor of handling the CPU architecture decision in the shared workflow itself.
 
 - `ecr-multi-arch-deploy-dev.yml`: Build/Publish Docker container in dev (for ECS or Lambda)
 - `ecr-multi-arch-deploy-stage.yml`: Build/Publish Docker container in stage (for ECS or Lambda)
@@ -82,7 +82,7 @@ These workflows include an input variable that allows the developer to choose ei
 
 **DEPRECATED**: The caller workflows are generated programmatically by the [mitlib-tf-workloads-ecr](https://github.com/MITLibraries/mitlib-tf-workloads-ecr) repository and then are copy/pasted from the Terraform Cloud outputs into the calling application repository.
 
-Moving forward, the caller workflows will be part of the template repositories for the various Python applications.
+**Note**: Moving forward, the caller workflows will be part of the template repositories for the various Python applications.
 
 ### ecr-multi-arch-deploy-dev.yml & ecr-multi-arch-deploy-stage.yml
 

--- a/README.md
+++ b/README.md
@@ -74,33 +74,35 @@ There are three workflows associated with publishing Docker containers to AWS EC
 
 **Note**: *While these workflows publish containers to ECR they do ***NOT*** force ECS services to restart with the new container.*
 
-These workflows include an input variable that allows the developer to choose either `linux/amd64` or `linux/arm6` as the CPU architecture for the built container.
+These workflows include an input variable that allows the developer to choose either `linux/amd64` or `linux/arm64` as the CPU architecture for the built container.
 
 - `ecr-multi-arch-deploy-dev.yml`: Build/Publish Docker container in dev (for ECS or Lambda)
 - `ecr-multi-arch-deploy-stage.yml`: Build/Publish Docker container in stage (for ECS or Lambda)
 - `ecr-multi-arch-promote-prod.yml`: Copy Docker container from stage to prod (for ECS or Lambda)
 
-The caller workflows are generated programmatically by the [mitlib-tf-workloads-ecr](https://github.com/MITLibraries/mitlib-tf-workloads-ecr) repository and then are copy/pasted from the Terraform Cloud outputs into the calling application repository.
+**DEPRECATED**: The caller workflows are generated programmatically by the [mitlib-tf-workloads-ecr](https://github.com/MITLibraries/mitlib-tf-workloads-ecr) repository and then are copy/pasted from the Terraform Cloud outputs into the calling application repository.
+
+Moving forward, the caller workflows will be part of the template repositories for the various Python applications.
 
 ### ecr-multi-arch-deploy-dev.yml & ecr-multi-arch-deploy-stage.yml
 
-These two workflows are the same. They require
+These two workflows are functionally the same. They require
 
 - shared secrets that exists in our MITLibraries GitHub Organization
 - a caller workflow that passes expected values to the shared workflow
 
-The container that is pushed to the AWS ECR Repository in Dev1 is tagged with
+The image that is pushed to the AWS ECR Repository in Dev1 is tagged with
 
 - the short (8 character) SHA of the most recent commit on the feature branch that generated the PR
 - the PR number for the repo
 - the word `latest` (or `latest-arm64` or `latest-amd64`)
 
-The container that is pushed to the AWS ECR Repository in Stage-Workloads is tagged with
+The image that is pushed to the AWS ECR Repository in Stage-Workloads is tagged with
 
 - the short (8 character) SHA of the merge commit
 - the word `latest` (or `latest-arm64` or `latest-amd64`)
 
-The workflow requires a `CPU_ARCH` input. This is used to pick the GitHub-hosted runner architecture for the whole job and then it is used during the Docker build step to build the container for the correct architecture. See [partner-runner-images](https://github.com/actions/partner-runner-images?tab=readme-ov-file) for information related to `ARM64` based GitHub-hosted runners (the default GitHub-hosted runner is based on `AMD64`).
+The first step the workflow verifies the CPU architecture for the image and passes this information on to the build-push job so that the build-push job can run on the same CPU architecture. See [partner-runner-images](https://github.com/actions/partner-runner-images?tab=readme-ov-file) for information related to `ARM64` based GitHub-hosted runners (the default GitHub-hosted runner is based on `AMD64`).
 
 ### ecr-multi-arch-promote-prod.yml
 
@@ -109,7 +111,7 @@ The promote to prod workflow just copies the container from stage to prod to ens
 The caller workflows for this shared workflow are configured with `on.workflow_dispatch` and `on.release.types: [published]`. The former allows for manual deploys from the GitHub UI and the latter is for deploying to production when a new release tag is issued. But, we want to ensure that only tagged releases on the `main` branch of the calling repository will trigger a run (we don't want a published tag on a feature branch to unintentionally push something to Production). So, we add a conditional for the `job.deploy` that checks the calling branch:
 
 ```yaml
-    if: ${{ github.ref == 'refs/heads/main' || github.event.release.target_commitish == 'main' }}
+    if: ${{ github.event.release.target_commitish == inputs.DEFAULT_BRANCH }}
 ```
 
 The `github.ref` value gets set when the trigger is a release tag. The `github.event.release.target_commitish` value gets set when the trigger is `workflow_dispatch`.
@@ -125,6 +127,42 @@ The container that is pushed to the AWS ECR Repository in Prod is tagged with
 ### Additional Requirements/Dependencies
 
 It also assumes that the appropriate infrastructure is in place, particularly the OIDC configuration and IAM role for Github Actions to connect to AWS. In most cases, this is handled by the [mitlib-tf-workloads-ecr](https://github.com/mitlibraries/mitlib-tf-workloads-ecr) repository. That same repository generates the GHA workflow files for each ECR repository so that they can be copied from Terraform Cloud into the application repository.
+
+### Examples
+
+A sample `dev-build.yml` workflow will look like this (same goes for `stage-build.yml`):
+
+```yaml
+  build-push:
+    name: Dev Build and Push
+    uses: mitlibraries/.github/.github/workflows/ecr-multi-arch-deploy-dev.yml@main
+    secrets: inherit
+    with:
+      AWS_REGION: "us-east-1"
+      GHA_ROLE: "<iam_role_for_repository>"
+      ECR: "<ecr_name>"
+      # FUNCTION: "" # only if this is a container-based Lambda function
+      # PREBUILD:  # only if there is some pre-build dependency
+```
+
+The `prod-promote.yml` workflow will look like this:
+
+```yaml
+  build-push:
+    needs: prep
+    name: Deploy
+    uses: mitlibraries/.github/.github/workflows/ecr-multi-arch-promote-prod.yml@main
+    secrets: inherit
+    with:
+      AWS_REGION: "us-east-1"
+      GHA_ROLE_STAGE: "<iam_role_for_repository_stage>"
+      GHA_ROLE_PROD: "<iam_role_for_repository_prod>"
+      ECR_STAGE: "<ecr_name_stage>"
+      ECR_PROD: "<ecr_name_prod>"
+      # FUNCTION: "" # only if this is a container-based Lambda function
+ ```
+
+If the application repo is building a container for a Lambda function, the developer must include the `FUNCTION: "${function}"` line. If the application (Python or Ruby) has additional pre-build commands that must be run before the `docker-build` command is run, they need to be added to the `PREBUILD"` argument. It is best if these are handled by the `Makefile`/`Rakefile`, so that the `PREBUILD:` line is just a list of `make`/`rake` commands.
 
 ## DEPRECATED: Build and Publish Containers
 


### PR DESCRIPTION
### Why these changes are being introduced

The work on TIMDEX and AOSS has highlighted the need to accelerate the IN-1481 Epic (migrating to ECR workflows that can handle AMD64 AND ARM64 architectures).

The Dev workflow was tested earlier today with Christopher & Graham in both the [timdex-index-manager](https://github.com/MITLibraries/timdex-index-manager) and the [browsertrix-harvester](https://github.com/MITLibraries/browsertrix-harvester) repositories with no issues at all.

### How this addresses that need

* Update the three multi-arch workflows by including the "prep" job that had been in the caller workflow until now
* Organize the workflow into three jobs for clearer separation of steps
* Update the README

### Side effects of this change

No impactful side effects. For caller applications that have already updated to these workflows, the "prep" job will run twice, but this will have no impact on the build/push/deploy steps.

### Relevant ticket(s)

* [IN-1732](https://mitlibraries.atlassian.net/browse/IN-1732)


[IN-1732]: https://mitlibraries.atlassian.net/browse/IN-1732?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ