### PR TITLE
Bug Fix!

### DIFF
--- a/.github/workflows/ecr-multi-arch-promote-prod.yml
+++ b/.github/workflows/ecr-multi-arch-promote-prod.yml
@@ -83,7 +83,7 @@ jobs:
     # E.g., download from Stage then upload to Prod
     runs-on: ubuntu-latest
     outputs:
-      tag_latest: ${{ steps.tags.outputs.tag_latest }}
+      tag_latest: ${{ steps.cpu_arch.outputs.tag_latest }}
       sha_match: ${{ steps.check_sha.outputs.sha_match }}
 
     steps:


### PR DESCRIPTION
### Why these changes are being introduced

The first attempt to use this updated workflow to redeploy a Lambda function from an ECR image failed because ECS could not find the image. ECS could not find the image because there was not value in the TAG_LATEST environment variable for the bash command in the step. There was not value for that environment variable because the `outputs` statement for the `promote` job referenced the wrong step for that value.

* See [timdex-pipeline-lambdas v3.0 release action run](https://github.com/MITLibraries/timdex-pipeline-lambdas/actions/runs/24357019494/job/71126697710) for the run that failed.
* In particular, in the step that failed, it's clear that there was no value for `TAG_LATEST`:
```yaml
  env:
    AWS_DEFAULT_REGION: us-east-1
    AWS_REGION: us-east-1
    AWS_ACCESS_KEY_ID: ***
    AWS_SECRET_ACCESS_KEY: ***
    AWS_SESSION_TOKEN: ***
    REGISTRY_PROD: ***.dkr.ecr.us-east-1.amazonaws.com
    REPOSITORY_PROD: timdex-pipeline-lambdas-prod
    TAG_LATEST: 
    FUNCTION: timdex-format-prod
```


### How this addresses that need

* Update the `outputs` block for the `promote` job to reference the correct step where the `tag_latest` value is set (it's in the `cpuarch` job, not in the `tags` job)
 
### Side effects of this change

No.
