### PR TITLE
Update github actions versions

### DIFF
--- a/.github/workflows/ruby-shared-ci.yml
+++ b/.github/workflows/ruby-shared-ci.yml
@@ -8,9 +8,9 @@ jobs:
     name: Run Tests and Coverage
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ruby/setup-ruby@v1
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: vendor/bundle
           key: bundle-use-ruby-ubuntu-22.04-${{ hashFiles('.ruby-version') }}-${{ hashFiles('**/Gemfile.lock') }}


### PR DESCRIPTION
### Why these changes are being introduced

We are seeing warnings in github actions dashboards about our use of checkout@v4 and cache@v4. There are newer versions of each available.

For an example message, see:

https://github.com/MITLibraries/tacos/actions/runs/24371005310

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/cache@v4, actions/checkout@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

### How this addresses that need

This updates our use of checkout from v4 to v6, and our use of cache from v4 to v5. Both are the latest releases of these actions.

We previously made this change in the WordPress repo as part of MITLibraries/mitlib-wp-network#192 (commit [d10f5dc](https://github.com/MITLibraries/mitlib-wp-network/pull/192/changes/d10f5dc222fdad20822fb7ea0780126741107252)) and it seems to have resolved the issue.

[WordPress CI run 1069 (shows warnings)](https://github.com/MITLibraries/mitlib-wp-network/actions/runs/23264408606)

[WordPress CI run 1071 (shows no warnings)](https://github.com/MITLibraries/mitlib-wp-network/actions/runs/23266773903)

### Side effects of this change

Hopefully none.


### Relevant ticket(s)

n/a
