### PR TITLE
Another Fix for Terraform-docs

### DIFF
--- a/.github/workflows/tf-docs-shared.yml
+++ b/.github/workflows/tf-docs-shared.yml
@@ -17,9 +17,9 @@ jobs:
     - uses: actions/checkout@v6
       with:
         ref: ${{ github.event.pull_request.head.ref }}
-    - uses: actions/setup-python@v6
-      with:
-        python-version: '3.13'
-    - uses: pre-commit/action@v3.0.1
-      with:
-        extra_args: terraform-docs-go --all-files
+
+    - name: Install pre-commit
+      run: pip install pre-commit
+    
+    - name: terraform-docs check
+      run: pre-commit run terraform-docs-go --all-files


### PR DESCRIPTION
### Why these changes are being introduced

The `pre-commit/action` appears to be very low on the priority list for maintenance and is stuck using another action with is stuck on node.js 20. Since we have no expectation that this third party action will get updated, we are simply going to install pre-commit directly in the workflow.

### How this addresses that need

* Add a step to the tf-docs workflow to install `pre-commit` with pip
* Run `pre-commit` directly and use it to only run the `terraform-docs-go` hook

### Side effects of this change

None.

